### PR TITLE
Add Windows pipeline to CI builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # evo 
 
-[![Build Status](https://travis-ci.org/MichaelGrupp/evo.svg?branch=master)](https://travis-ci.org/MichaelGrupp/evo)
-
 ***Python package for the evaluation of odometry and SLAM***
+
+| Linux | Windows |
+| :---: | :-----: |
+| [![Linux build Status](https://travis-ci.org/MichaelGrupp/evo.svg?branch=master)](https://travis-ci.org/MichaelGrupp/evo) | [![Windows build status](https://ci.appveyor.com/api/projects/status/usg1lqx59dqdqqal?svg=true)](https://ci.appveyor.com/project/MichaelGrupp/evo)
+
 
 This packages provides executables and a small library for handling, evaluating and comparing the trajectory output of odometry and SLAM algorithms.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python34-x64"
+    # - PYTHON: "C:\\Python34-x64"  # had some problems, need to investigate
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+
+install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "%PYTHON%\\python.exe -m pip install . --upgrade"
+  - "evo_config set plot_backend Agg"
+
+build: off
+
+test_script:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "%PYTHON%\\python.exe -m pip install pytest --upgrade"
+  - "pytest -sv"

--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -166,8 +166,6 @@ class PlotCollection:
         if confirm_overwrite and not user.check_and_confirm_overwrite(dest):
             return
         else:
-            if os.name == "nt":
-                raise PlotException("plot serialization not supported on Windows")
             pickle.dump(self.figures, open(dest, 'wb'))
 
     def export(self, file_path, confirm_overwrite=True):

--- a/evo/tools/settings_template.py
+++ b/evo/tools/settings_template.py
@@ -99,7 +99,7 @@ DEFAULT_SETTINGS_DICT_DOC = {
     ),
     "plot_seaborn_palette": (
         "deep",
-        "Default color palette of seaborn.\n"
+        "Default color palette of seaborn. Can also be a list of colors.\n"
         + "See: https://seaborn.pydata.org/generated/seaborn.color_palette.html"
     ),
     "plot_export_format": (

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import os
 import sys
 import shutil
 import subprocess as sp
-from pwd import getpwnam
 
 
 # monkey patch because setuptools entry_points are slow as fuck
@@ -21,41 +20,48 @@ def python_below_34():
     return sys.version_info[0] < 3 or sys.version_info[1] < 4
 
 
-def run_as_caller():
-    caller = os.environ["SUDO_USER"] if "SUDO_USER" in os.environ else os.environ["USER"]
+def _run_as_caller():
+    if os.name == "nt":
+        return
+    from pwd import getpwnam
+    if "SUDO_USER" in os.environ:
+        caller = os.environ["SUDO_USER"]
+    else:
+        caller = os.environ["USER"]
     uid = getpwnam(caller).pw_uid
     gid = getpwnam(caller).pw_gid
     os.setgid(gid)
     os.setuid(uid)
 
 
-def _post_install(install_lib_dir):
+def _get_home_dir():
+    user = os.getenv("SUDO_USER")
+    if user is not None:
+        home_dir = os.path.expanduser("~{}".format(user))
+    else:
+        home_dir = os.path.expanduser("~")
+    return home_dir
+
+
+def install_ipython_profile(install_lib_dir):
     from evo.tools.compat import which
-    # argcomplete
-    print("activating argcomplete")
-    try:
-        sp.check_call("activate-global-python-argcomplete", shell=True)
-        print("done - argcomplete should work now")
-    except sp.CalledProcessError as e:
-        print("error:", e.output, file=sys.stderr)
-    # IPython profile
-    user = os.environ["SUDO_USER"] if "SUDO_USER" in os.environ else os.environ["USER"]
-    home_dir = os.path.expanduser("~{}".format(user))
+    home_dir = _get_home_dir()
     ipython_dir = os.path.join(home_dir, ".ipython")
     os.environ["IPYTHONDIR"] = ipython_dir
-    print("installing evo IPython profile for user", user)
+    print("Installing evo IPython profile...")
     ipython = "ipython3" if sys.version_info >= (3, 0) else "ipython2"
     if which(ipython) is None:
-        # fall back to the non-explicit ipython name if ipython2/3 is not in PATH
+        # Use the non-explicit ipython name if ipython2/3 is not in PATH.
         ipython = "ipython"
         if which(ipython) is None:
             print("IPython is not installed", file=sys.stderr)
             return
     try:
         sp.check_call([ipython, "profile", "create", "evo",
-                       "--ipython-dir", ipython_dir], preexec_fn=run_as_caller)
+                       "--ipython-dir", ipython_dir], 
+                       preexec_fn=_run_as_caller)
         profile_dir = sp.check_output([ipython, "profile", "locate", "evo"],
-                                      preexec_fn=run_as_caller)
+                                      preexec_fn=_run_as_caller)
         if sys.version_info >= (3, 0):
             profile_dir = profile_dir.decode("UTF-8").replace("\n", "")
         else:
@@ -63,16 +69,32 @@ def _post_install(install_lib_dir):
         shutil.copy(os.path.join(install_lib_dir, "evo", "ipython_config.py"),
                     os.path.join(profile_dir, "ipython_config.py"))
     except sp.CalledProcessError as e:
-        print("IPython error", e.output, file=sys.stderr)
+        print("IPython error:", e.output, file=sys.stderr)
     except Exception as e:
-        print("unexpected error", e.message, file=sys.stderr)
+        print("Unexpected error:", e.message, file=sys.stderr)
+
+
+def activate_argcomplete():
+    if os.name == "nt":
+        return
+    print("Activating argcomplete...")
+    try:
+        sp.check_call("activate-global-python-argcomplete", shell=True)
+        print("Done - argcomplete should work now.")
+    except sp.CalledProcessError as e:
+        print("Error:", e.output, file=sys.stderr)
+
+
+def _post_install(install_lib_dir):
+    activate_argcomplete()
+    install_ipython_profile(install_lib_dir)
 
 
 class CustomInstall(install):
     def run(self):
         install.run(self)
         self.execute(_post_install, (self.install_lib,),
-                     msg="running post install task")
+                     msg="Running post install task of evo...")
 
 
 # cmd: python setup.py upload

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def install_ipython_profile(install_lib_dir):
             return
     try:
         sp.check_call([ipython, "profile", "create", "evo",
-                       "--ipython-dir", ipython_dir], 
+                       "--ipython-dir", ipython_dir],
                        preexec_fn=_run_as_caller)
         profile_dir = sp.check_output([ipython, "profile", "locate", "evo"],
                                       preexec_fn=_run_as_caller)


### PR DESCRIPTION
Adds Windows support to evo.

For now, this is only tested by running the pipeline on AppVeyor,
but it should work also on a normal Windows desktop.