### PR TITLE
Revert to classic seaborn plot color palette.

### DIFF
--- a/evo/tools/settings_template.py
+++ b/evo/tools/settings_template.py
@@ -95,7 +95,7 @@ DEFAULT_SETTINGS_DICT_DOC = {
         + "Options: 'whitegrid', 'darkgrid', 'white' or 'dark'."
     ),
     "plot_seaborn_palette": (
-        "deep",
+        "deep6",
         "Default color palette of seaborn. Can also be a list of colors.\n"
         + "See: https://seaborn.pydata.org/generated/seaborn.color_palette.html"
     ),


### PR DESCRIPTION
Seaborn changed its default "deep" color palette to use a new color
scheme that looks pretty ugly.

Use the "legacy" color palette that was used in previous versions of
seaborn, which is now called "deep6".

See https://github.com/mwaskom/seaborn/blob/1acf26b7965ff26355b81d8257c6e3e0e865dfe5/doc/releases/v0.9.0.txt#L31