### PR TITLE
rosbag format: use time from msg header

### DIFF
--- a/evo/tools/file_interface.py
+++ b/evo/tools/file_interface.py
@@ -199,8 +199,8 @@ def read_bag_trajectory(bag_handle, topic):
         raise FileInterfaceException(
             "unsupported message type: {}".format(msg_type))
     stamps, xyz, quat = [], [], []
-    for topic, msg, trec in bag_handle.read_messages(topic):
-        # Use the msg time instead of time msg was recorded
+    for topic, msg, _ in bag_handle.read_messages(topic):
+        # Use the header timestamps (converted to seconds).
         t = msg.header.stamp
         stamps.append(t.secs + (t.nsecs * 1e-9))
         # Make nav_msgs/Odometry behave like geometry_msgs/PoseStamped.

--- a/evo/tools/file_interface.py
+++ b/evo/tools/file_interface.py
@@ -199,7 +199,9 @@ def read_bag_trajectory(bag_handle, topic):
         raise FileInterfaceException(
             "unsupported message type: {}".format(msg_type))
     stamps, xyz, quat = [], [], []
-    for topic, msg, t in bag_handle.read_messages(topic):
+    for topic, msg, trec in bag_handle.read_messages(topic):
+        # Use the msg time instead of time msg was recorded
+        t = msg.header.stamp
         stamps.append(t.secs + (t.nsecs * 1e-9))
         # Make nav_msgs/Odometry behave like geometry_msgs/PoseStamped.
         while not hasattr(msg.pose, 'position') and not hasattr(


### PR DESCRIPTION
I was running `evo` on a rosbag that I captured from [VINS-Mono](https://github.com/HKUST-Aerial-Robotics/VINS-Mono) and comparing against the EuRoC ground truth csv using the following code:

```python
import rosbag
from evo.tools import file_interface
from evo.core import sync

bag_handle = rosbag.Bag("vinsmono-eurocMH1.bag")
traj_est = file_interface.read_bag_trajectory(bag_handle, "/vins_estimator/odometry")
traj_ref = file_interface.read_euroc_csv_trajectory("data.csv")
traj_ref, traj_est = sync.associate_trajectories(traj_ref, traj_est)
```

However, `associate_trajectories` was throwing an exception because the offset between when I *recorded* the bag today and when the original EuRoC rosbag dataset was recorded was too much.

This patch parses `traj_est` using the ros msg header time stamp (which is the same as the original EuRoC rosbag dataset when using `use_sim_time` and `rosbag play ... --clock`). With this fix I was able to successfully use `evo`.

Thanks for the awesome tools!