### PR TITLE
Make reference trajectory plot style configurable.

### DIFF
--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -119,8 +119,9 @@ def plot(args, result, traj_ref, traj_est):
     # Plot the values color-mapped onto the trajectory.
     fig2 = plt.figure(figsize=SETTINGS.plot_figsize)
     ax = plot.prepare_axis(fig2, plot_mode)
-    plot.traj(ax, plot_mode, traj_ref, '--', 'black', 'reference',
-              alpha=0.0 if SETTINGS.plot_hideref else 0.5)
+    plot.traj(ax, plot_mode, traj_ref, style=SETTINGS.plot_reference_linestyle,
+              color=SETTINGS.plot_reference_color, label='reference',
+              alpha=SETTINGS.plot_reference_alpha)
 
     if args.plot_colormap_min is None:
         args.plot_colormap_min = result.stats["min"]

--- a/evo/main_config.py
+++ b/evo/main_config.py
@@ -71,9 +71,9 @@ def merge_json_union(first, second, soft=False):
         f_1.write(json.dumps(cfg_1, indent=4, sort_keys=True))
 
 
-def is_number(s):
+def is_number(token):
     try:
-        float(s)
+        float(token)
         return True
     except ValueError:
         return False
@@ -238,7 +238,7 @@ def main():
     argcomplete.autocomplete(main_parser)
     if len(sys.argv) > 1 and sys.argv[1] == "set":
         args, other_args = main_parser.parse_known_args()
-        other_args = [arg for arg in sys.argv[2:] if not arg.startswith('-')]
+        other_args = [arg for arg in sys.argv[2:]]
     else:
         args, other_args = main_parser.parse_known_args()
     log.configure_logging()

--- a/evo/main_traj.py
+++ b/evo/main_traj.py
@@ -357,12 +357,19 @@ def run(args):
             short_traj_name = os.path.splitext(os.path.basename(args.ref))[0]
             if SETTINGS.plot_usetex:
                 short_traj_name = short_traj_name.replace("_", "\\_")
-            plot.traj(ax_traj, plot_mode, ref_traj, '--', 'grey',
-                      short_traj_name, alpha=0 if SETTINGS.plot_hideref else 1)
-            plot.traj_xyz(axarr_xyz, ref_traj, '--', 'grey', short_traj_name,
-                          alpha=0 if SETTINGS.plot_hideref else 1)
-            plot.traj_rpy(axarr_rpy, ref_traj, '--', 'grey', short_traj_name,
-                          alpha=0 if SETTINGS.plot_hideref else 1)
+            plot.traj(ax_traj, plot_mode, ref_traj,
+                      style=SETTINGS.plot_reference_linestyle,
+                      color=SETTINGS.plot_reference_color,
+                      label=short_traj_name,
+                      alpha=SETTINGS.plot_reference_alpha)
+            plot.traj_xyz(
+                axarr_xyz, ref_traj, style=SETTINGS.plot_reference_linestyle,
+                color=SETTINGS.plot_reference_color, label=short_traj_name,
+                alpha=SETTINGS.plot_reference_alpha)
+            plot.traj_rpy(
+                axarr_rpy, ref_traj, style=SETTINGS.plot_reference_linestyle,
+                color=SETTINGS.plot_reference_color, label=short_traj_name,
+                alpha=SETTINGS.plot_reference_alpha)
 
         cmap_colors = None
         if SETTINGS.plot_multi_cmap.lower() != "none":

--- a/evo/tools/settings_template.py
+++ b/evo/tools/settings_template.py
@@ -40,10 +40,6 @@ DEFAULT_SETTINGS_DICT_DOC = {
         get_default_plot_backend(),
         "matplotlib backend - default: 'Qt{4, 5}Agg' (if PyQt is installed) or 'TkAgg'."
     ),
-    "plot_hideref": (
-        False,
-        "Hide the reference trajectory in trajectory plots."
-    ),
     "plot_linewidth": (
         1.5,
         "Line width value supported by matplotlib."
@@ -102,6 +98,18 @@ DEFAULT_SETTINGS_DICT_DOC = {
     "plot_export_format": (
         "pdf",
         "File format supported by matplotlib for exporting plots."
+    ),
+    "plot_reference_alpha": (
+        0.5,
+        "Alpha value of the reference trajectories in plots."
+    ),
+    "plot_reference_color": (
+        "black",
+        "Color of the reference trajectories in plots."
+    ),
+    "plot_reference_linestyle": (
+        "--",
+        "matplotlib linestyle of reference trajectories in plots."
     ),
     "table_export_format": (
         "csv",


### PR DESCRIPTION
Adds these parameters that can be changed with `evo_config`:
- `plot_reference_alpha`
- `plot_reference_color`
- `plot_reference_linestyle`

Removes `plot_hideref`.