### PR TITLE
Use Xenial and change the tested Python versions in the CI matrix.

### DIFF
--- a/.ci/mac-os_before_install.sh
+++ b/.ci/mac-os_before_install.sh
@@ -7,9 +7,14 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   brew install openssl readline
   brew outdated pyenv || brew upgrade pyenv
 
+  # As recommended by Homebrew's "keg-only" warning.
+  export LDFLAGS="-L /usr/local/opt/readline/lib"
+  export CPPFLAGS="-I /usr/local/opt/readline/include"
+  export PKG_CONFIG_PATH="/usr/local/opt/readline/lib/pkgconfig"
+
   brew install pyenv-virtualenv
   eval "$(pyenv init -)"
-  eval "$(pyenv virtualenv-init -)"
+  eval "$(pyenv virtualenv-init -)"  
   pyenv install $PYTHON
 
   export PYENV_VERSION=$PYTHON

--- a/.ci/mac-os_before_install.sh
+++ b/.ci/mac-os_before_install.sh
@@ -7,14 +7,9 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   brew install openssl readline
   brew outdated pyenv || brew upgrade pyenv
 
-  # As recommended by Homebrew's "keg-only" warning.
-  export LDFLAGS="-L /usr/local/opt/readline/lib"
-  export CPPFLAGS="-I /usr/local/opt/readline/include"
-  export PKG_CONFIG_PATH="/usr/local/opt/readline/lib/pkgconfig"
-
   brew install pyenv-virtualenv
   eval "$(pyenv init -)"
-  eval "$(pyenv virtualenv-init -)"  
+  eval "$(pyenv virtualenv-init -)"
   pyenv install $PYTHON
 
   export PYENV_VERSION=$PYTHON

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
 
+dist: xenial
 sudo: required
 services: docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,18 @@ services: docker
 language: python
 
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 # Python for Mac is not yet officially supported by Travis.
-# We test only 2.7 and 3.6 on macOS for now.
+# We test only Python 3.7 on macOS for now with a custom setup script.
+# Python 2.7 is required for ROS, so this is tested in the ROS Dockerfile.
 matrix:
   include:
     - os: osx
       language: generic
-      env: PYTHON=2.7.10
-    - os: osx
-      language: generic
-      env: PYTHON=3.6.0
+      env: PYTHON=3.7.0
     - os: linux
       language: python
       env: 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,7 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python27-x64"
-    # - PYTHON: "C:\\Python34-x64"  # had some problems, need to investigate
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"


### PR DESCRIPTION
- drop support for Trusty, use Xenial
- drop support for Python 3.4
- add Python 3.7 to all platforms
- remove Python 2.7 from all platforms except for ROS docker build