### PR TITLE
Add --ignore_title option to evo_res.

### DIFF
--- a/evo/entry_points.py
+++ b/evo/entry_points.py
@@ -88,6 +88,8 @@ def launch(main_module, parser):
     from evo import EvoException
     try:
         main_module.run(args)
+    except KeyboardInterrupt:
+        sys.exit(1)
     except SystemExit as e:
         sys.exit(e.code)
     except EvoException as e:


### PR DESCRIPTION
Sometimes it makes sense to aggregate also if the titles don't match.
This option allows to do that and no title is printed or shown in the
plot.

Just `--no_warnings` has a similar effect, but the title is still shown then.
