### PR TITLE
Fixes problem in case that, traj_short is the same length  as the matching indices

### DIFF
--- a/evo/core/sync.py
+++ b/evo/core/sync.py
@@ -87,7 +87,8 @@ def associate_trajectories(traj_1, traj_2, max_diff=0.01, offset_2=0.0,
     matching_indices = matching_time_indices(
         traj_long.timestamps, traj_short.timestamps, max_diff,
         -offset_2 if snd_longer else offset_2)
-    traj_short.reduce_to_ids(matching_indices)
+    if len(traj_short.timestamps) > len(matching_indices):
+        traj_short.reduce_to_ids(matching_indices)
 
     traj_1 = traj_short if snd_longer else traj_long
     traj_2 = traj_long if snd_longer else traj_short


### PR DESCRIPTION
For my usecase, a scenario came up where every point from the long trajectory matched with one from the short one and therefore the length of traj_short was the same as the length of matching_indices. This happens because I am using a high frequency Opti Track system as reference. With the added if statement the problem went away and there were no other problems that came up as a result.