### PR TITLE
Improve usability of evo_traj alignment options.

### DIFF
--- a/evo/main_traj.py
+++ b/evo/main_traj.py
@@ -318,7 +318,7 @@ def run(args):
                 name, args.t_offset))
             traj.timestamps += args.t_offset
 
-    if args.n_to_align and not (args.align or args.correct_scale):
+    if args.n_to_align != -1 and not (args.align or args.correct_scale):
         die("--n_to_align is useless without --align or/and --correct_scale")
 
     if args.sync or args.align or args.correct_scale or args.align_origin:

--- a/evo/main_traj.py
+++ b/evo/main_traj.py
@@ -318,6 +318,9 @@ def run(args):
                 name, args.t_offset))
             traj.timestamps += args.t_offset
 
+    if args.n_to_align and not (args.align or args.correct_scale):
+        die("--n_to_align is useless without --align or/and --correct_scale")
+
     if args.sync or args.align or args.correct_scale or args.align_origin:
         from evo.core import sync
         if not args.ref:
@@ -339,7 +342,7 @@ def run(args):
                     correct_scale=args.correct_scale,
                     correct_only_scale=args.correct_scale and not args.align,
                     n=args.n_to_align)
-            elif args.align_origin:
+            if args.align_origin:
                 logger.debug(SEP)
                 logger.debug("Aligning {}'s origin to reference.".format(name))
                 trajectories[name] = trajectory.align_trajectory_origin(


### PR DESCRIPTION
- error if --n_to_align is used without alignment options
- allow to use scale correction together with origin alignment