### PR TITLE
Remove IPython profile installation from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,61 +18,6 @@ def python_below_34():
     return sys.version_info[0] < 3 or sys.version_info[1] < 4
 
 
-def _run_as_caller():
-    if os.name == "nt":
-        return
-    from pwd import getpwnam
-    if "SUDO_USER" in os.environ:
-        caller = os.environ["SUDO_USER"]
-    else:
-        caller = os.environ["USER"]
-    uid = getpwnam(caller).pw_uid
-    gid = getpwnam(caller).pw_gid
-    os.setgid(gid)
-    os.setuid(uid)
-
-
-def _get_home_dir():
-    user = os.getenv("SUDO_USER")
-    if user is not None:
-        home_dir = os.path.expanduser("~{}".format(user))
-    else:
-        home_dir = os.path.expanduser("~")
-    return home_dir
-
-
-def install_ipython_profile(install_lib_dir):
-    from evo.tools.compat import which
-    home_dir = _get_home_dir()
-    ipython_dir = os.path.join(home_dir, ".ipython")
-    os.environ["IPYTHONDIR"] = ipython_dir
-    print("Installing evo IPython profile...")
-    ipython = "ipython3" if sys.version_info >= (3, 0) else "ipython2"
-    if which(ipython) is None:
-        # Use the non-explicit ipython name if ipython2/3 is not in PATH.
-        ipython = "ipython"
-        if which(ipython) is None:
-            print("IPython is not installed", file=sys.stderr)
-            return
-    try:
-        sp.check_call([
-            ipython, "profile", "create", "evo", "--ipython-dir", ipython_dir
-        ], preexec_fn=_run_as_caller)
-        profile_dir = sp.check_output([ipython, "profile", "locate", "evo"],
-                                      preexec_fn=_run_as_caller)
-        if sys.version_info >= (3, 0):
-            profile_dir = profile_dir.decode("UTF-8").replace("\n", "")
-        else:
-            profile_dir = profile_dir.replace("\n", "")
-        shutil.copy(
-            os.path.join(install_lib_dir, "evo", "ipython_config.py"),
-            os.path.join(profile_dir, "ipython_config.py"))
-    except sp.CalledProcessError as e:
-        print("IPython error:", e.output, file=sys.stderr)
-    except Exception as e:
-        print("Unexpected error:", e.message, file=sys.stderr)
-
-
 def activate_argcomplete():
     if os.name == "nt":
         return
@@ -86,7 +31,6 @@ def activate_argcomplete():
 
 def _post_install(install_lib_dir):
     activate_argcomplete()
-    install_ipython_profile(install_lib_dir)
 
 
 class CustomInstall(install):


### PR DESCRIPTION
WIll be done on demand when evo_ipython is called.
preexec_fn is also not supported on Windows.