### PR TITLE
Fix #216: patch so3_log for very small angles.

### DIFF
--- a/evo/core/lie_algebra.py
+++ b/evo/core/lie_algebra.py
@@ -20,11 +20,18 @@ along with evo.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import numpy as np
-import scipy.linalg as sl
 import scipy.spatial.transform as sst
+from distutils.version import LooseVersion
+from scipy import __version__ as scipy_version
 
 from evo import EvoException
 from evo.core import transformations as tr
+
+# scipy.spatial.transform.Rotation.*_matrix() was introduced in 1.4,
+# which is not available for Python 2.7.
+# Use the legacy direct cosine matrix naming (*_dcm()) if needed.
+# TODO: remove this junk once Python 2.7 is finally dead in ROS.
+_USE_DCM_NAME = LooseVersion(scipy_version) < LooseVersion("1.4")
 
 
 class LieAlgebraException(EvoException):
@@ -51,37 +58,41 @@ def vee(m):
     return np.array([-m[1, 2], m[0, 2], -m[0, 1]])
 
 
-def so3_exp(axis, angle):
+def so3_exp(rotation_vector):
     """
-    Computes an SO(3) matrix from an axis/angle representation.
-    Code source: http://stackoverflow.com/a/25709323
-    :param axis: 3x1 rotation axis (unit vector!)
-    :param angle: radians
+    Computes an SO(3) matrix from a rotation vector representation.
+    :param axis: 3x1 rotation vector (axis * angle)
     :return: SO(3) rotation matrix (matrix exponential of so(3))
     """
-    return sl.expm(np.cross(np.eye(3), axis / np.linalg.norm(axis) * angle))
-
+    if _USE_DCM_NAME:
+        return sst.Rotation.from_rotvec(rotation_vector).as_dcm()
+    else:
+        return sst.Rotation.from_rotvec(rotation_vector).as_matrix()
 
 def so3_log(r, return_angle_only=True, return_skew=False):
     """
     :param r: SO(3) rotation matrix
     :param return_angle_only: return only the angle (default)
     :param return_skew: return skew symmetric Lie algebra element
-    :return: axis/angle
-        or if skew:
+    :return:
+        if return_angle_only is False:
+            rotation vector (axis * angle)
+        or if return_skew is True:
              3x3 skew symmetric logarithmic map in so(3) (Ma, Soatto eq. 2.8)
     """
     if not is_so3(r):
         raise LieAlgebraException("matrix is not a valid SO(3) group element")
-    rotation = sst.Rotation.from_matrix(r)
-    rotation_vector = rotation.as_rotvec()
-    if return_angle_only and not return_skew:
-        return np.linalg.norm(rotation_vector)
-    angle, axis, _ = tr.rotation_from_matrix(se3(r, [0, 0, 0]))
-    if return_skew:
-        return hat(axis * angle)
+    if _USE_DCM_NAME:
+        rotation_vector = sst.Rotation.from_dcm(r).as_rotvec()
     else:
-        return axis, angle
+        rotation_vector = sst.Rotation.from_matrix(r).as_rotvec()
+    angle = np.linalg.norm(rotation_vector)
+    if return_angle_only and not return_skew:
+        return angle
+    if return_skew:
+        return hat(rotation_vector)
+    else:
+        return rotation_vector
 
 
 def se3(r=np.eye(3), t=np.array([0, 0, 0])):

--- a/evo/core/lie_algebra.py
+++ b/evo/core/lie_algebra.py
@@ -21,6 +21,7 @@ along with evo.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 import scipy.linalg as sl
+import scipy.spatial.transform as sst
 
 from evo import EvoException
 from evo.core import transformations as tr
@@ -72,8 +73,10 @@ def so3_log(r, return_angle_only=True, return_skew=False):
     """
     if not is_so3(r):
         raise LieAlgebraException("matrix is not a valid SO(3) group element")
+    rotation = sst.Rotation.from_matrix(r)
+    rotation_vector = rotation.as_rotvec()
     if return_angle_only and not return_skew:
-        return np.arccos(min(1, max(-1, (np.trace(r) - 1) / 2)))
+        return np.linalg.norm(rotation_vector)
     angle, axis, _ = tr.rotation_from_matrix(se3(r, [0, 0, 0]))
     if return_skew:
         return hat(axis * angle)

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -93,17 +93,17 @@ class TestFilterPairsByPath(unittest.TestCase):
 
 axis = np.array([1, 0, 0])
 poses_5 = [
-    lie.se3(lie.so3_exp(axis, 0.0), np.array([0, 0, 0])),
-    lie.se3(lie.so3_exp(axis, math.pi), np.array([0, 0, 0])),
-    lie.se3(lie.so3_exp(axis, 0.0), np.array([0, 0, 0])),
-    lie.se3(lie.so3_exp(axis, math.pi / 3), np.array([0, 0, 0])),
-    lie.se3(lie.so3_exp(axis, math.pi), np.array([0, 0, 0]))
+    lie.se3(lie.so3_exp(axis * 0.0), np.array([0, 0, 0])),
+    lie.se3(lie.so3_exp(axis * math.pi), np.array([0, 0, 0])),
+    lie.se3(lie.so3_exp(axis * 0.0), np.array([0, 0, 0])),
+    lie.se3(lie.so3_exp(axis * math.pi / 3), np.array([0, 0, 0])),
+    lie.se3(lie.so3_exp(axis * math.pi), np.array([0, 0, 0]))
 ]
 stamps_5 = np.array([0, 1, 2, 3, 4])
 
 axis = np.array([1, 0, 0])
-p0 = lie.se3(lie.so3_exp(axis, 0.0), np.array([0, 0, 0]))
-pd = lie.se3(lie.so3_exp(axis, math.pi / 3), np.array([1, 2, 3]))
+p0 = lie.se3(lie.so3_exp(axis * 0.0), np.array([0, 0, 0]))
+pd = lie.se3(lie.so3_exp(axis * (math.pi / 3.)), np.array([1, 2, 3]))
 p1 = np.dot(p0, pd)
 p2 = np.dot(p1, pd)
 p3 = np.dot(p2, pd)
@@ -113,8 +113,8 @@ stamps_6 = np.array([0, 1, 2, 3, 4])
 
 class TestFilterPairsByAngle(unittest.TestCase):
     def test_poses5(self):
-        target_angle = math.pi
         tol = 0.001
+        target_angle = math.pi - tol
         id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
                                                  all_pairs=False)
         self.assertEqual(id_pairs, [(0, 1), (1, 2), (2, 4)])
@@ -127,8 +127,8 @@ class TestFilterPairsByAngle(unittest.TestCase):
         self.assertEqual(id_pairs, [(0, 1), (0, 4), (1, 2), (2, 4)])
 
     def test_poses6(self):
-        target_angle = math.pi
         tol = 0.001
+        target_angle = math.pi - tol
         id_pairs = filters.filter_pairs_by_angle(poses_6, target_angle, tol,
                                                  all_pairs=False)
         self.assertEqual(id_pairs, [(0, 3)])

--- a/test/test_lie_algebra.py
+++ b/test/test_lie_algebra.py
@@ -94,22 +94,17 @@ class TestSO3(unittest.TestCase):
     def test_so3_log_exp(self):
         r = lie.random_so3()
         self.assertTrue(lie.is_so3(r))
-        axis, angle = lie.so3_log(r, return_angle_only=False)
-        self.assertTrue(np.allclose(r, lie.so3_exp(axis, angle), atol=1e-6))
+        rotvec = lie.so3_log(r, return_angle_only=False)
+        self.assertTrue(np.allclose(r, lie.so3_exp(rotvec), atol=1e-6))
         angle = lie.so3_log(r)
-        # we ignore signs here, therefore check also transpose
-        self.assertTrue(
-            np.allclose(r,
-                        lie.so3_exp(axis, angle).T)
-            or np.allclose(r, lie.so3_exp(axis, angle)))
+        self.assertAlmostEqual(np.linalg.norm(rotvec), angle)
 
     def test_so3_log_exp_skew(self):
         r = lie.random_so3()
         log = lie.so3_log(r, return_skew=True)  # skew-symmetric tangent space
         # here, axis is a rotation vector with norm = angle
-        axis = lie.vee(log)
-        angle = np.linalg.norm(axis)
-        self.assertTrue(np.allclose(r, lie.so3_exp(axis, angle)))
+        rotvec = lie.vee(log)
+        self.assertTrue(np.allclose(r, lie.so3_exp(rotvec)))
 
 
 class TestSim3(unittest.TestCase):
@@ -160,9 +155,9 @@ if __name__ == '__main__':
                         number=1000))
     setup = "from evo.core import lie_algebra as lie; " \
             "import numpy as np; so3 = lie.random_so3(); " \
-            "axis, angle = lie.so3_log(so3, False)"
-    print("time for 1000*lie.so3_exp(axis, angle): ",
-          timeit.timeit("lie.so3_exp(axis, angle)", setup=setup, number=1000))
+            "rotvec = lie.so3_log(so3, False)"
+    print("time for 1000*lie.so3_exp(rotvec): ",
+          timeit.timeit("lie.so3_exp(rotvec)", setup=setup, number=1000))
     """
     unit test
     """


### PR DESCRIPTION
Use `scipy.spatial.transform` stuff as a more stable alternative.

Addresses the problem of #216 where an angular RPE was unstable for almost zero
rotations. For most comparisons with angular pose relation this patch doesn't change
much except for very small numeric differences.

Also relates to #139.