### PR TITLE
Handle alignment of "motionless" trajectories

### DIFF
--- a/evo/core/geometry.py
+++ b/evo/core/geometry.py
@@ -54,12 +54,6 @@ def umeyama_alignment(x, y, with_scale=False):
     # variance, eq. 36
     # "transpose" for column subtraction
     sigma_x = 1.0 / n * (np.linalg.norm(x - mean_x[:, np.newaxis])**2)
-    sigma_y = 1.0 / n * (np.linalg.norm(y - mean_y[:, np.newaxis])**2)
-
-    # trajectories collapse to almost a single point
-    if sigma_x < 1e-8 or sigma_y < 1e-8:
-        logger.debug("Either of trajectories collapse to one point.")
-        return None, None, 0.0
 
     # covariance matrix, eq. 38
     outer_sum = np.zeros((m, m))
@@ -69,6 +63,9 @@ def umeyama_alignment(x, y, with_scale=False):
 
     # SVD (text betw. eq. 38 and 39)
     u, d, v = np.linalg.svd(cov_xy)
+    if np.count_nonzero(d > np.finfo(d.dtype).eps) < m - 1:
+        raise GeometryException("Degenerate covariance rank, "
+                                "Umeyama alignment is not possible")
 
     # S matrix, eq. 43
     s = np.eye(m)

--- a/evo/core/geometry.py
+++ b/evo/core/geometry.py
@@ -17,13 +17,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with evo.  If not, see <http://www.gnu.org/licenses/>.
 """
-import logging
 
 import numpy as np
 
 from evo import EvoException
-
-logger = logging.getLogger(__name__)
 
 
 class GeometryException(EvoException):

--- a/evo/core/geometry.py
+++ b/evo/core/geometry.py
@@ -17,10 +17,13 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with evo.  If not, see <http://www.gnu.org/licenses/>.
 """
+import logging
 
 import numpy as np
 
 from evo import EvoException
+
+logger = logging.getLogger(__name__)
 
 
 class GeometryException(EvoException):
@@ -51,6 +54,12 @@ def umeyama_alignment(x, y, with_scale=False):
     # variance, eq. 36
     # "transpose" for column subtraction
     sigma_x = 1.0 / n * (np.linalg.norm(x - mean_x[:, np.newaxis])**2)
+    sigma_y = 1.0 / n * (np.linalg.norm(y - mean_y[:, np.newaxis])**2)
+
+    # trajectories collapse to almost a single point
+    if sigma_x < 1e-8 or sigma_y < 1e-8:
+        logger.debug("Either of trajectories collapse to one point.")
+        return None, None, 0.0
 
     # covariance matrix, eq. 38
     outer_sum = np.zeros((m, m))

--- a/evo/core/trajectory.py
+++ b/evo/core/trajectory.py
@@ -401,15 +401,6 @@ def align_trajectory(traj, traj_ref, correct_scale=False,
             traj_aligned.positions_xyz[:n, :].T,
             traj_ref.positions_xyz[:n, :].T, with_scale)
 
-    # could not compute transformation with Umeyama alignment
-    # compute transform between trajectory origins
-    if r_a is None or t_a is None:
-        transform = traj_ref.poses_se3[0].dot(
-            lie.se3_inverse(traj.poses_se3[0]))
-        r_a = transform[:3, :3]
-        t_a = transform[:3, 3]
-        s = 1.0
-
     if not correct_only_scale:
         logger.debug("Rotation of alignment:\n{}"
                      "\nTranslation of alignment:\n{}".format(r_a, t_a))

--- a/test/test_trajectory.py
+++ b/test/test_trajectory.py
@@ -28,6 +28,7 @@ import context
 import helpers
 from evo.core import trajectory
 from evo.core import lie_algebra as lie
+from evo.core.trajectory import PoseTrajectory3D
 
 
 class TestPosePath3D(unittest.TestCase):
@@ -185,6 +186,32 @@ class TestTrajectoryAlignment(unittest.TestCase):
         self.assertFalse(np.allclose(traj_1.poses_se3[0], traj_2.poses_se3[0]))
         traj_2 = trajectory.align_trajectory_origin(traj_2, traj_1)
         self.assertTrue(np.allclose(traj_1.poses_se3[0], traj_2.poses_se3[0]))
+
+    def test_sim3_alignment_motionless_case(self):
+        length = 100
+        poses = [lie.se3()] * length
+        traj_1 = PoseTrajectory3D(
+            poses_se3=poses,
+            timestamps=helpers.fake_timestamps(length, 1, 0.0))
+        traj_2 = copy.deepcopy(traj_1)
+        traj_2.transform(lie.random_se3())
+        traj_2.scale(1.234)
+        self.assertNotEqual(traj_1, traj_2)
+        traj_aligned = trajectory.align_trajectory(traj_1, traj_2,
+                                                   correct_scale=True)
+        self.assertEqual(traj_aligned, traj_2)
+
+    def test_se3_alignment_motionless_case(self):
+        length = 100
+        poses = [lie.random_se3()] * length
+        traj_1 = PoseTrajectory3D(
+            poses_se3=poses,
+            timestamps=helpers.fake_timestamps(length, 1, 0.0))
+        traj_2 = copy.deepcopy(traj_1)
+        traj_2.transform(lie.random_se3())
+        self.assertNotEqual(traj_1, traj_2)
+        traj_aligned = trajectory.align_trajectory(traj_1, traj_2)
+        self.assertEqual(traj_aligned, traj_2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Recently I encountered a case, where I had to evaluate absolute error between two trajectories, where one was depicting static motion (i.e. same pose (e.g. identity) for each timestamp). In this situation, **umeyama_alignment** call fails with division by 0 at https://github.com/MichaelGrupp/evo/blob/master/evo/core/geometry.py#L74. With this PR I aim to detect this situation and perform alignment by trajectory origin instead. Although it is rather a rare situation, but, in my opinion, yet a possible output from one of the SLAM pipelines. In the PR I also included some test cases to replicate the observed behavior.