### PR TITLE
Remove unnecessary plot_export_format from settings.

### DIFF
--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -179,8 +179,8 @@ class PlotCollection:
             pickle.dump(self.figures, open(dest, 'wb'))
 
     def export(self, file_path: str, confirm_overwrite: bool = True) -> None:
-        fmt = SETTINGS.plot_export_format.lower()
-        if fmt == "pdf" and not SETTINGS.plot_split:
+        fmt = os.path.splitext(file_path)[1]
+        if fmt == ".pdf" and not SETTINGS.plot_split:
             if confirm_overwrite and not user.check_and_confirm_overwrite(
                     file_path):
                 return
@@ -199,7 +199,7 @@ class PlotCollection:
                         dest):
                     return
                 fig.tight_layout()
-                fig.savefig(dest, fmt=fmt)
+                fig.savefig(dest)
                 logger.info("Plot saved to " + dest)
 
 

--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -179,8 +179,8 @@ class PlotCollection:
             pickle.dump(self.figures, open(dest, 'wb'))
 
     def export(self, file_path: str, confirm_overwrite: bool = True) -> None:
-        fmt = os.path.splitext(file_path)[1]
-        if fmt == ".pdf" and not SETTINGS.plot_split:
+        base, ext = os.path.splitext(file_path)
+        if ext == ".pdf" and not SETTINGS.plot_split:
             if confirm_overwrite and not user.check_and_confirm_overwrite(
                     file_path):
                 return
@@ -193,7 +193,6 @@ class PlotCollection:
             logger.info("Plots saved to " + file_path)
         else:
             for name, fig in self.figures.items():
-                base, ext = os.path.splitext(file_path)
                 dest = base + '_' + name + ext
                 if confirm_overwrite and not user.check_and_confirm_overwrite(
                         dest):

--- a/evo/tools/settings_template.py
+++ b/evo/tools/settings_template.py
@@ -74,10 +74,6 @@ DEFAULT_SETTINGS_DICT_DOC = {
         ("Statistics that are included in plots of evo_{ape, rpe, res}.\n"
          "Can also be set to 'none'.")
     ),
-    "plot_export_format": (
-        "pdf",
-        "File format supported by matplotlib for exporting plots."
-    ),
     "plot_figsize": (
         [6, 6],
         "The default size of one (sub)plot figure (width, height)."


### PR DESCRIPTION
Just use file extension.

closes #373