### PR TITLE
Install types-PyYAML for mypy check in CI.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
     displayName: 'Install and configure package and dependencies'
 
   - script: |
-      pip install mypy
+      pip install mypy types-PyYAML
       mypy --ignore-missing-imports evo/ test/ contrib/ doc/
     displayName: 'mypy'
 


### PR DESCRIPTION
"Starting in mypy 0.900, most third-party package stubs must be
installed explicitly"