### PR TITLE
Support masking unknown cells with more ROS map image formats.

### DIFF
--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -687,7 +687,7 @@ def ros_map(ax: plt.Axes, yaml_path: str, plot_mode: PlotMode,
             image = np.ma.masked_where(image == mask_unknown_value_rgb[0],
                                        image)
         elif n_channels == 3:
-            # imshow doesn't like masked RGB images for some reason,
+            # imshow ignores masked RGB regions for some reason,
             # add an alpha channel instead.
             # https://stackoverflow.com/questions/60561680
             mask = np.all(image == mask_unknown_value_rgb, 2)

--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -672,19 +672,24 @@ def ros_map(ax: plt.Axes, yaml_path: str, plot_mode: PlotMode,
         image_path = os.path.join(os.path.dirname(yaml_path), image_path)
     image = plt.imread(image_path)
     if mask_unknown_value:
-        n_channels = image.shape[2]
+        n_channels = image.shape[2] if len(image.shape) > 2 else 1
         if image.dtype == np.uint8 and n_channels == 1:
             # Support for 8bit grayscale image.
-            image = np.ma.masked_where(image == np.uint8(mask_unknown_value), image)
+            image = np.ma.masked_where(image == np.uint8(mask_unknown_value),
+                                       image)
         elif image.dtype == np.float32 and n_channels == 3:
             # Support for float32 RGB image.
-            mask_unknown_value_rgb = np.array([mask_unknown_value / 255.0] * 3, dtype=np.float32)
-            image = np.ma.masked_where(np.all(image == mask_unknown_value_rgb, 2), image[:,:,0])
-            print(image.shape)
+            mask_unknown_value_rgb = np.array([mask_unknown_value / 255.0] * 3,
+                                              dtype=np.float32)
+            mask = np.all(image == mask_unknown_value_rgb, 2)
+            # imshow doesn't like masked RGB images for some reason, add an
+            # alpha channel instead.
+            image = np.dstack((image, (~mask).astype(np.float32)))
+            print(image[-1, -1])
         else:
-            raise PlotException(
-                "masking unknown cells is not supported with "
-                "{}-channel {} pixels".format(n_channels, image.dtype))
+            raise PlotException("masking unknown cells is not supported with "
+                                "{}-channel {} pixels".format(
+                                    n_channels, image.dtype))
 
     # Squeeze extent to reflect metric coordinates.
     resolution = metadata["resolution"]

--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -694,6 +694,7 @@ def ros_map(ax: plt.Axes, yaml_path: str, plot_mode: PlotMode,
             max_alpha = 255 if image.dtype == np.uint8 else 1.
             image = np.dstack((image, (~mask).astype(image.dtype) * max_alpha))
         else:
+            # E.g. if there's already an alpha channel it doesn't make sense.
             logger.warn("masking unknown map cells is not supported with "
                         "{}-channel {} pixels".format(n_channels, image.dtype))
 


### PR DESCRIPTION
Besides 8-bit PGM now also 3-channel PNG, JPEG and float pixels.