### PR TITLE
Fix: calculate angle filter delta on SO(3) manifold.

### DIFF
--- a/evo/core/filters.py
+++ b/evo/core/filters.py
@@ -99,7 +99,7 @@ def filter_pairs_by_angle(poses: typing.Sequence[np.ndarray], delta: float,
                           tol: float = 0.0, degrees: bool = False,
                           all_pairs: bool = False) -> IdPairs:
     """
-    filters pairs in a list of SE(3) poses by their absolute relative angle
+    filters pairs in a list of SE(3) poses by their relative angle
      - by default, the angle accumulated on the path between the two pair poses
        is considered
      - if <all_pairs> is set to True, the direct angle between the two pair

--- a/evo/core/filters.py
+++ b/evo/core/filters.py
@@ -144,8 +144,8 @@ def filter_pairs_by_angle(poses: typing.Sequence[np.ndarray], delta: float,
             id_pairs.extend([(i, j) for j in matches.flatten().tolist()])
     else:
         delta_angles = [
-            lie.so3_log_angle(lie.relative_so3(p1[:3, :3], p2[:3, :3]),
-                              degrees) for p1, p2 in zip(poses, poses[1:])
+            lie.so3_log_angle(lie.relative_so3(p1[:3, :3], p2[:3, :3]))
+            for p1, p2 in zip(poses, poses[1:])
         ]
         accumulated_delta = 0.0
         current_start_index = 0

--- a/evo/core/filters.py
+++ b/evo/core/filters.py
@@ -136,7 +136,7 @@ def filter_pairs_by_angle(poses: typing.Sequence[np.ndarray], delta: float,
             rotations_i = lie.sst_rotation_from_matrix(
                 np.array([poses[i][:3, :3]] * len(end_indices)))
             rotations_j = lie.sst_rotation_from_matrix(
-                np.array([poses[j][:3, :3] for j in ids[end_indices]]))
+                np.array([poses[j][:3, :3] for j in end_indices]))
             delta_angles = np.linalg.norm(
                 (rotations_i.inv() * rotations_j).as_rotvec(), axis=1)
             matches = np.argwhere((lower_bound <= delta_angles)

--- a/evo/core/filters.py
+++ b/evo/core/filters.py
@@ -127,15 +127,16 @@ def filter_pairs_by_angle(poses: typing.Sequence[np.ndarray], delta: float,
         # scipy.spatial.transform.Rotation for quicker processing.
         logger.info("Searching all pairs with matching rotation delta,"
                     " this can take a while.")
-        for i in ids[:-1]:
+        start_indices = ids[:-1]
+        for i in start_indices:
             if not i % 100:
-                print(int(i / len(ids[:-1]) * 100), "%", end="\r")
+                print(int(i / len(start_indices) * 100), "%", end="\r")
             offset = i + 1
-            assert len(ids[offset:]) > 0
+            end_indices = ids[offset:]
             rotations_i = lie.sst_rotation_from_matrix(
-                np.array([poses[i][:3, :3]] * len(ids[offset:])))
+                np.array([poses[i][:3, :3]] * len(end_indices)))
             rotations_j = lie.sst_rotation_from_matrix(
-                np.array([poses[j][:3, :3] for j in ids[offset:]]))
+                np.array([poses[j][:3, :3] for j in ids[end_indices]]))
             delta_angles = np.linalg.norm(
                 (rotations_i.inv() * rotations_j).as_rotvec(), axis=1)
             matches = np.argwhere((lower_bound <= delta_angles)

--- a/evo/core/lie_algebra.py
+++ b/evo/core/lie_algebra.py
@@ -40,6 +40,18 @@ class LieAlgebraException(EvoException):
     pass
 
 
+def sst_rotation_from_matrix(so3_matrices: np.ndarray):
+    """
+    Helper for creating scipy.spatial.transform.Rotation
+    from 1..n SO(3) matrices.
+    :return: scipy.spatial.transform.Rotation
+    """
+    if _USE_DCM_NAME:
+        return sst.Rotation.from_dcm(so3_matrices)
+    else:
+        return sst.Rotation.from_matrix(so3_matrices)
+
+
 def hat(v: np.ndarray) -> np.ndarray:
     """
     :param v: 3x1 vector
@@ -83,10 +95,7 @@ def so3_log(r: np.ndarray, return_skew: bool = False) -> np.ndarray:
     """
     if not is_so3(r):
         raise LieAlgebraException("matrix is not a valid SO(3) group element")
-    if _USE_DCM_NAME:
-        rotation_vector = sst.Rotation.from_dcm(r).as_rotvec()
-    else:
-        rotation_vector = sst.Rotation.from_matrix(r).as_rotvec()
+    rotation_vector = sst_rotation_from_matrix(r).as_rotvec()
     if return_skew:
         return hat(rotation_vector)
     else:

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -27,6 +27,7 @@ import numpy as np
 from evo.core import filters
 from evo.core import lie_algebra as lie
 
+# TODO: clean these up and use proper fixtures.
 poses_1 = [
     lie.se3(np.eye(3), np.array([0, 0, 0])),
     lie.se3(np.eye(3), np.array([0, 0, 0.5])),
@@ -99,6 +100,8 @@ poses_5 = [
     lie.se3(lie.so3_exp(axis * math.pi), np.array([0, 0, 0]))
 ]
 stamps_5 = np.array([0, 1, 2, 3, 4])
+transform = lie.random_se3()
+poses_5_transformed = [transform.dot(p) for p in poses_5]
 
 axis = np.array([1, 0, 0])
 p0 = lie.se3(lie.so3_exp(axis * 0.0), np.array([0, 0, 0]))
@@ -109,12 +112,23 @@ p3 = np.dot(p2, pd)
 poses_6 = [p0, p1, p2, p3, p3]
 stamps_6 = np.array([0, 1, 2, 3, 4])
 
+poses_6_transformed = [transform.dot(p) for p in poses_6]
+
 
 class TestFilterPairsByAngle(unittest.TestCase):
     def test_poses5(self):
         tol = 0.001
         target_angle = math.pi - tol
         id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
+                                                 all_pairs=False)
+        self.assertEqual(id_pairs, [(0, 1), (1, 2), (2, 4)])
+
+    def test_poses5_transformed(self):
+        """ Result should be unaffected by global transformation """
+        tol = 0.001
+        target_angle = math.pi - tol
+        id_pairs = filters.filter_pairs_by_angle(poses_5_transformed,
+                                                 target_angle, tol,
                                                  all_pairs=False)
         self.assertEqual(id_pairs, [(0, 1), (1, 2), (2, 4)])
 
@@ -125,6 +139,15 @@ class TestFilterPairsByAngle(unittest.TestCase):
                                                  all_pairs=True)
         self.assertEqual(id_pairs, [(0, 1), (0, 4), (1, 2), (2, 4)])
 
+    def test_poses5_transformed_all_pairs(self):
+        """ Result should be unaffected by global transformation """
+        target_angle = math.pi
+        tol = 0.01
+        id_pairs = filters.filter_pairs_by_angle(poses_5_transformed,
+                                                 target_angle, tol,
+                                                 all_pairs=True)
+        self.assertEqual(id_pairs, [(0, 1), (0, 4), (1, 2), (2, 4)])
+
     def test_poses6(self):
         tol = 0.001
         target_angle = math.pi - tol
@@ -132,10 +155,28 @@ class TestFilterPairsByAngle(unittest.TestCase):
                                                  all_pairs=False)
         self.assertEqual(id_pairs, [(0, 3)])
 
+    def test_poses6_transformed(self):
+        """ Result should be unaffected by global transformation """
+        tol = 0.001
+        target_angle = math.pi - tol
+        id_pairs = filters.filter_pairs_by_angle(poses_6_transformed,
+                                                 target_angle, tol,
+                                                 all_pairs=False)
+        self.assertEqual(id_pairs, [(0, 3)])
+
     def test_poses6_all_pairs(self):
         target_angle = math.pi
         tol = 0.001
         id_pairs = filters.filter_pairs_by_angle(poses_6, target_angle, tol,
+                                                 all_pairs=True)
+        self.assertEqual(id_pairs, [(0, 3), (0, 4)])
+
+    def test_poses6_transformed_all_pairs(self):
+        """ Result should be unaffected by global transformation """
+        target_angle = math.pi
+        tol = 0.001
+        id_pairs = filters.filter_pairs_by_angle(poses_6_transformed,
+                                                 target_angle, tol,
                                                  all_pairs=True)
         self.assertEqual(id_pairs, [(0, 3), (0, 4)])
 

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -118,77 +118,55 @@ poses_6_transformed = [transform.dot(p) for p in poses_6]
 class TestFilterPairsByAngle(unittest.TestCase):
     def test_poses5(self):
         tol = 0.001
-        target_angle = math.pi - tol
-        id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
-                                                 all_pairs=False)
-        self.assertEqual(id_pairs, [(0, 1), (1, 2), (2, 4)])
-        # Check for same result when using degrees:
-        target_angle = np.rad2deg(target_angle)
-        id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
-                                                 all_pairs=False, degrees=True)
-        self.assertEqual(id_pairs, [(0, 1), (1, 2), (2, 4)])
-
-    def test_poses5_transformed(self):
-        """ Result should be unaffected by global transformation """
-        tol = 0.001
-        target_angle = math.pi - tol
-        id_pairs = filters.filter_pairs_by_angle(poses_5_transformed,
-                                                 target_angle, tol,
-                                                 all_pairs=False)
-        self.assertEqual(id_pairs, [(0, 1), (1, 2), (2, 4)])
+        expected_result = [(0, 1), (1, 2), (2, 4)]
+        # Result should be unaffected by global transformation.
+        for poses in (poses_5, poses_5_transformed):
+            target_angle = math.pi - tol
+            id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
+                                                     all_pairs=False)
+            self.assertEqual(id_pairs, expected_result)
+            # Check for same result when using degrees:
+            target_angle = np.rad2deg(target_angle)
+            id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
+                                                     all_pairs=False,
+                                                     degrees=True)
+            self.assertEqual(id_pairs, expected_result)
 
     def test_poses5_all_pairs(self):
-        target_angle = math.pi
         tol = 0.01
-        id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
-                                                 all_pairs=True)
-        self.assertEqual(id_pairs, [(0, 1), (0, 4), (1, 2), (2, 4)])
-        # Check for same result when using degrees:
-        target_angle = np.rad2deg(target_angle)
-        id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
-                                                 all_pairs=True, degrees=True)
-        self.assertEqual(id_pairs, [(0, 1), (0, 4), (1, 2), (2, 4)])
-
-    def test_poses5_transformed_all_pairs(self):
-        """ Result should be unaffected by global transformation """
-        target_angle = math.pi
-        tol = 0.01
-        id_pairs = filters.filter_pairs_by_angle(poses_5_transformed,
-                                                 target_angle, tol,
-                                                 all_pairs=True)
-        self.assertEqual(id_pairs, [(0, 1), (0, 4), (1, 2), (2, 4)])
+        expected_result = [(0, 1), (0, 4), (1, 2), (2, 4)]
+        # Result should be unaffected by global transformation.
+        for poses in (poses_5, poses_5_transformed):
+            target_angle = math.pi
+            id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
+                                                     all_pairs=True)
+            self.assertEqual(id_pairs, expected_result)
+            # Check for same result when using degrees:
+            target_angle = np.rad2deg(target_angle)
+            id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
+                                                     all_pairs=True,
+                                                     degrees=True)
+            self.assertEqual(id_pairs, expected_result)
 
     def test_poses6(self):
         tol = 0.001
         target_angle = math.pi - tol
-        id_pairs = filters.filter_pairs_by_angle(poses_6, target_angle, tol,
-                                                 all_pairs=False)
-        self.assertEqual(id_pairs, [(0, 3)])
-
-    def test_poses6_transformed(self):
-        """ Result should be unaffected by global transformation """
-        tol = 0.001
-        target_angle = math.pi - tol
-        id_pairs = filters.filter_pairs_by_angle(poses_6_transformed,
-                                                 target_angle, tol,
-                                                 all_pairs=False)
-        self.assertEqual(id_pairs, [(0, 3)])
+        expected_result = [(0, 3)]
+        # Result should be unaffected by global transformation.
+        for poses in (poses_6, poses_6_transformed):
+            id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
+                                                     all_pairs=False)
+            self.assertEqual(id_pairs, expected_result)
 
     def test_poses6_all_pairs(self):
         target_angle = math.pi
         tol = 0.001
-        id_pairs = filters.filter_pairs_by_angle(poses_6, target_angle, tol,
-                                                 all_pairs=True)
-        self.assertEqual(id_pairs, [(0, 3), (0, 4)])
-
-    def test_poses6_transformed_all_pairs(self):
-        """ Result should be unaffected by global transformation """
-        target_angle = math.pi
-        tol = 0.001
-        id_pairs = filters.filter_pairs_by_angle(poses_6_transformed,
-                                                 target_angle, tol,
-                                                 all_pairs=True)
-        self.assertEqual(id_pairs, [(0, 3), (0, 4)])
+        expected_result = [(0, 3), (0, 4)]
+        # Result should be unaffected by global transformation.
+        for poses in (poses_6, poses_6_transformed):
+            id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
+                                                     all_pairs=True)
+            self.assertEqual(id_pairs, expected_result)
 
 
 if __name__ == '__main__':

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -122,6 +122,11 @@ class TestFilterPairsByAngle(unittest.TestCase):
         id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
                                                  all_pairs=False)
         self.assertEqual(id_pairs, [(0, 1), (1, 2), (2, 4)])
+        # Check for same result when using degrees:
+        target_angle = np.rad2deg(target_angle)
+        id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
+                                                 all_pairs=False, degrees=True)
+        self.assertEqual(id_pairs, [(0, 1), (1, 2), (2, 4)])
 
     def test_poses5_transformed(self):
         """ Result should be unaffected by global transformation """
@@ -137,6 +142,11 @@ class TestFilterPairsByAngle(unittest.TestCase):
         tol = 0.01
         id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
                                                  all_pairs=True)
+        self.assertEqual(id_pairs, [(0, 1), (0, 4), (1, 2), (2, 4)])
+        # Check for same result when using degrees:
+        target_angle = np.rad2deg(target_angle)
+        id_pairs = filters.filter_pairs_by_angle(poses_5, target_angle, tol,
+                                                 all_pairs=True, degrees=True)
         self.assertEqual(id_pairs, [(0, 1), (0, 4), (1, 2), (2, 4)])
 
     def test_poses5_transformed_all_pairs(self):

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -28,21 +28,21 @@ from evo.core import filters
 from evo.core import lie_algebra as lie
 
 # TODO: clean these up and use proper fixtures.
-poses_1 = [
+POSES_1 = [
     lie.se3(np.eye(3), np.array([0, 0, 0])),
     lie.se3(np.eye(3), np.array([0, 0, 0.5])),
     lie.se3(np.eye(3), np.array([0, 0, 0])),
     lie.se3(np.eye(3), np.array([0, 0, 1]))
 ]
 
-poses_2 = [
+POSES_2 = [
     lie.se3(np.eye(3), np.array([0, 0, 0])),
     lie.se3(np.eye(3), np.array([0, 0, 0.5])),
     lie.se3(np.eye(3), np.array([0, 0, 0.99])),
     lie.se3(np.eye(3), np.array([0, 0, 1.0]))
 ]
 
-poses_3 = [
+POSES_3 = [
     lie.se3(np.eye(3), np.array([0, 0, 0.0])),
     lie.se3(np.eye(3), np.array([0, 0, 0.9])),
     lie.se3(np.eye(3), np.array([0, 0, 0.99])),
@@ -53,7 +53,7 @@ poses_3 = [
     lie.se3(np.eye(3), np.array([0, 0, 0.9999999]))
 ]
 
-poses_4 = [
+POSES_4 = [
     lie.se3(np.eye(3), np.array([0, 0, 0])),
     lie.se3(np.eye(3), np.array([0, 0, 1])),
     lie.se3(np.eye(3), np.array([0, 0, 1])),
@@ -65,43 +65,42 @@ class TestFilterPairsByPath(unittest.TestCase):
     def test_poses1_all_pairs(self):
         target_path = 1.0
         tol = 0.0
-        id_pairs = filters.filter_pairs_by_path(poses_1, target_path, tol,
+        id_pairs = filters.filter_pairs_by_path(POSES_1, target_path, tol,
                                                 all_pairs=True)
         self.assertEqual(id_pairs, [(0, 2), (2, 3)])
 
     def test_poses1_wrong_target(self):
         target_path = 2.5
         tol = 0.0
-        id_pairs = filters.filter_pairs_by_path(poses_1, target_path, tol,
+        id_pairs = filters.filter_pairs_by_path(POSES_1, target_path, tol,
                                                 all_pairs=True)
         self.assertEqual(id_pairs, [])
 
     def test_poses2_all_pairs_low_tolerance(self):
         target_path = 1.0
         tol = 0.001
-        id_pairs = filters.filter_pairs_by_path(poses_2, target_path, tol,
+        id_pairs = filters.filter_pairs_by_path(POSES_2, target_path, tol,
                                                 all_pairs=True)
         self.assertEqual(id_pairs, [(0, 3)])
 
     def test_convergence_all_pairs(self):
         target_path = 1.0
         tol = 0.2
-        id_pairs = filters.filter_pairs_by_path(poses_3, target_path, tol,
+        id_pairs = filters.filter_pairs_by_path(POSES_3, target_path, tol,
                                                 all_pairs=True)
         self.assertEqual(id_pairs, [(0, 7)])
 
 
 axis = np.array([1, 0, 0])
-poses_5 = [
+POSES_5 = [
     lie.se3(lie.so3_exp(axis * 0.0), np.array([0, 0, 0])),
     lie.se3(lie.so3_exp(axis * math.pi), np.array([0, 0, 0])),
     lie.se3(lie.so3_exp(axis * 0.0), np.array([0, 0, 0])),
     lie.se3(lie.so3_exp(axis * math.pi / 3), np.array([0, 0, 0])),
     lie.se3(lie.so3_exp(axis * math.pi), np.array([0, 0, 0]))
 ]
-stamps_5 = np.array([0, 1, 2, 3, 4])
-transform = lie.random_se3()
-poses_5_transformed = [transform.dot(p) for p in poses_5]
+TRANSFORM = lie.random_se3()
+POSES_5_TRANSFORMED = [TRANSFORM.dot(p) for p in POSES_5]
 
 axis = np.array([1, 0, 0])
 p0 = lie.se3(lie.so3_exp(axis * 0.0), np.array([0, 0, 0]))
@@ -109,10 +108,8 @@ pd = lie.se3(lie.so3_exp(axis * (math.pi / 3.)), np.array([1, 2, 3]))
 p1 = np.dot(p0, pd)
 p2 = np.dot(p1, pd)
 p3 = np.dot(p2, pd)
-poses_6 = [p0, p1, p2, p3, p3]
-stamps_6 = np.array([0, 1, 2, 3, 4])
-
-poses_6_transformed = [transform.dot(p) for p in poses_6]
+POSES_6 = [p0, p1, p2, p3, p3]
+POSES_6_TRANSFORMED = [TRANSFORM.dot(p) for p in POSES_6]
 
 
 class TestFilterPairsByAngle(unittest.TestCase):
@@ -120,7 +117,7 @@ class TestFilterPairsByAngle(unittest.TestCase):
         tol = 0.001
         expected_result = [(0, 1), (1, 2), (2, 4)]
         # Result should be unaffected by global transformation.
-        for poses in (poses_5, poses_5_transformed):
+        for poses in (POSES_5, POSES_5_TRANSFORMED):
             target_angle = math.pi - tol
             id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
                                                      all_pairs=False)
@@ -136,7 +133,7 @@ class TestFilterPairsByAngle(unittest.TestCase):
         tol = 0.01
         expected_result = [(0, 1), (0, 4), (1, 2), (2, 4)]
         # Result should be unaffected by global transformation.
-        for poses in (poses_5, poses_5_transformed):
+        for poses in (POSES_5, POSES_5_TRANSFORMED):
             target_angle = math.pi
             id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
                                                      all_pairs=True)
@@ -153,7 +150,7 @@ class TestFilterPairsByAngle(unittest.TestCase):
         target_angle = math.pi - tol
         expected_result = [(0, 3)]
         # Result should be unaffected by global transformation.
-        for poses in (poses_6, poses_6_transformed):
+        for poses in (POSES_6, POSES_6_TRANSFORMED):
             id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
                                                      all_pairs=False)
             self.assertEqual(id_pairs, expected_result)
@@ -163,7 +160,7 @@ class TestFilterPairsByAngle(unittest.TestCase):
         tol = 0.001
         expected_result = [(0, 3), (0, 4)]
         # Result should be unaffected by global transformation.
-        for poses in (poses_6, poses_6_transformed):
+        for poses in (POSES_6, POSES_6_TRANSFORMED):
             id_pairs = filters.filter_pairs_by_angle(poses, target_angle, tol,
                                                      all_pairs=True)
             self.assertEqual(id_pairs, expected_result)


### PR DESCRIPTION
The previous implementation didn't make sense for 3D poses.
The unit test succeeded because it only tested the trivial case
in the 2D plane.

The new version uses the true delta rotation angle of each pair
as a measure.

Note: this only affects filtering and is unrelated to the rotation RPE,
which was already calculated on SO(3).