### PR TITLE
Add setting to scale pose axis marker of reference trajectory

### DIFF
--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -153,7 +153,7 @@ def plot_result(args: argparse.Namespace, result: Result, traj_ref: PosePath3D,
               color=SETTINGS.plot_reference_color, label='reference',
               alpha=SETTINGS.plot_reference_alpha)
     plot.draw_coordinate_axes(ax, traj_ref, plot_mode,
-                              SETTINGS.plot_axis_marker_scale)
+                              SETTINGS.plot_reference_axis_marker_scale)
 
     if args.plot_colormap_min is None:
         args.plot_colormap_min = result.stats["min"]

--- a/evo/main_traj.py
+++ b/evo/main_traj.py
@@ -447,7 +447,7 @@ def run(args):
                       label=short_traj_name,
                       alpha=SETTINGS.plot_reference_alpha)
             plot.draw_coordinate_axes(ax_traj, ref_traj, plot_mode,
-                                      SETTINGS.plot_axis_marker_scale)
+                                      SETTINGS.plot_reference_axis_marker_scale)
             plot.traj_xyz(
                 axarr_xyz, ref_traj, style=SETTINGS.plot_reference_linestyle,
                 color=SETTINGS.plot_reference_color, label=short_traj_name,

--- a/evo/tools/settings_template.py
+++ b/evo/tools/settings_template.py
@@ -121,7 +121,8 @@ DEFAULT_SETTINGS_DICT_DOC = {
     ),
     "plot_reference_axis_marker_scale": (
         0.,
-        "Scaling parameter of pose coordinate frame markers of reference trajectories. 0 will draw nothing."
+        "Scaling parameter of pose coordinate frame markers of reference trajectories. "
+        + "0 will draw nothing."
     ),
     "plot_seaborn_palette": (
         "deep6",

--- a/evo/tools/settings_template.py
+++ b/evo/tools/settings_template.py
@@ -119,6 +119,10 @@ DEFAULT_SETTINGS_DICT_DOC = {
         "--",
         "matplotlib linestyle of reference trajectories in plots."
     ),
+    "plot_reference_axis_marker_scale": (
+        0.,
+        "Scaling parameter of pose coordinate frame markers of reference trajectories. 0 will draw nothing."
+    ),
     "plot_seaborn_palette": (
         "deep6",
         "Default color cycle, taken from a palette of the seaborn package.\n"


### PR DESCRIPTION
Currently, a single setting `plot_axis_marker_scale` is used to scale axis when visualizing poses of reference and estimated trajectory. If reference and estimated trajectory are close and densely sampled, then it is difficult to distinguish the poses. Thus, I introduced `plot_reference_axis_marker_scale`, which enables axis of reference poses independently of estimated ones.
Example, reference as dashed line does not show poses whereas estimated trajectory does.
![image](https://user-images.githubusercontent.com/7974580/153562378-e33bb77b-e136-4a02-85c6-aaee10409cec.png)
