### PR TITLE
Close all figures after saving

### DIFF
--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -189,3 +189,4 @@ def plot_result(args: argparse.Namespace, result: Result, traj_ref: PosePath3D,
         logger.debug(SEP)
         plot_collection.serialize(args.serialize_plot,
                                   confirm_overwrite=not args.no_warnings)
+    plot_collection.close()

--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -183,6 +183,12 @@ class PlotCollection:
         else:
             plt.show()
 
+    def close(self) -> None:
+        if len(self.figures.keys()) == 0:
+            return
+        for name, fig in self.figures.items():
+            plt.close(fig)
+
     def serialize(self, dest: str, confirm_overwrite: bool = True) -> None:
         logger.debug("Serializing PlotCollection to " + dest + "...")
         if confirm_overwrite and not user.check_and_confirm_overwrite(dest):


### PR DESCRIPTION
When batch processing many files without showing figures but saving figures a warning about too many figures can occur `More than 20 figures have been opened.` etc. In order to avoid this warning, the following implementation closes all figures after saving or serialization.