### PR TITLE
Actual and not absolute point distance error

### DIFF
--- a/evo/core/metrics.py
+++ b/evo/core/metrics.py
@@ -66,7 +66,6 @@ class PoseRelation(Enum):
     point_distance = "point distance"
     point_distance_error_ratio = "point distance error ratio"
 
-
 class Unit(Enum):
     none = "unit-less"
     meters = "m"
@@ -270,7 +269,7 @@ class RPE(PE):
                 np.linalg.norm(traj_est.positions_xyz[i] -
                                traj_est.positions_xyz[j]) for i, j in id_pairs
             ])
-            self.error = np.abs(ref_distances - est_distances)
+            self.error = ref_distances - est_distances
             if self.pose_relation == PoseRelation.point_distance_error_ratio:
                 nonzero = ref_distances.nonzero()[0]
                 if nonzero.size != ref_distances.size:


### PR DESCRIPTION
Point distance error is currently defined as the absolute value of the difference between the point distance. I propose to use the actual and not absolute value, thus, allowing negative values. This is helpful to judge an "expansion" or "shrinkage" with respect to the reference trajectory.

Point distance error:
![image](https://user-images.githubusercontent.com/7974580/172546289-91f8f8de-6e27-4a81-83f7-a9fb29d35251.png)

Point distance error ratio:
![image](https://user-images.githubusercontent.com/7974580/172545717-1e92407c-33aa-4460-b835-0ab7fa8fe9b1.png)
