### PR TITLE
Add error metrics for scale error

### DIFF
--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -91,6 +91,8 @@ def get_pose_relation(args: argparse.Namespace) -> PoseRelation:
         pose_relation = PoseRelation.point_distance
     elif args.pose_relation == "point_distance_error_ratio":
         pose_relation = PoseRelation.point_distance_error_ratio
+    elif args.pose_relation == "scale_error":
+        pose_relation = PoseRelation.scale_error
     return pose_relation
 
 

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -51,7 +51,7 @@ def parser() -> argparse.ArgumentParser:
         "-r", "--pose_relation", default="trans_part",
         help="pose relation on which the RPE is based", choices=[
             "full", "trans_part", "rot_part", "angle_deg", "angle_rad",
-            "point_distance", "point_distance_error_ratio"
+            "point_distance", "point_distance_error_ratio", "scale_error"
         ])
     algo_opts.add_argument("-a", "--align",
                            help="alignment with Umeyama's method (no scale)",


### PR DESCRIPTION
Another useful measure, I think, is scale, that is the ratio of traveled distance of estimate over reference:
![image](https://user-images.githubusercontent.com/7974580/172842094-900fb465-af80-407d-bacc-eb98a44a93e4.png)
and derived thereof the scale error
![image](https://user-images.githubusercontent.com/7974580/172842205-4850a475-a1b6-4be7-abe8-904ff28582d6.png)
The implementation is part of the relative error measures. An example looks like this:
![image](https://user-images.githubusercontent.com/7974580/172842561-f9b14b3c-61f6-4ed1-a2f8-8d47a357fa38.png)
![image](https://user-images.githubusercontent.com/7974580/172842598-f89581b4-e56b-45f9-8cee-dec6a6bad376.png)
