### PR TITLE
Add numexpr to dependencies (for Pandas).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
         "matplotlib",
         "scipy>=1.2",
         "pandas",
+        "numexpr>=2.7.3"
         "seaborn>=0.9",
         "natsort",
         "argcomplete",

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         "matplotlib",
         "scipy>=1.2",
         "pandas",
-        "numexpr>=2.7.3"
+        "numexpr>=2.7.3",
         "seaborn>=0.9",
         "natsort",
         "argcomplete",


### PR DESCRIPTION
To prevent an annoying warning if the wrong version is installed.
Pandas recommends to install it:
https://pandas.pydata.org/docs/getting_started/install.html 