### PR TITLE
--ignore-installed in ROS Dockerfile

### DIFF
--- a/Dockerfile.rosgalactic
+++ b/Dockerfile.rosgalactic
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get -y install ros-galactic-tf2-ros
 RUN container-local/.ci/debian_install_pip3.sh
 
 # Build and install.
-RUN pip3 install /container-local --upgrade --no-binary evo
+RUN pip3 install --ignore-installed /container-local --upgrade --no-binary evo
 RUN evo_config show --brief --no_color
 
 # Run tests.

--- a/Dockerfile.rosnoetic
+++ b/Dockerfile.rosnoetic
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get -y install ros-noetic-tf2-ros
 RUN container-local/.ci/debian_install_pip3.sh
 
 # Build and install.
-RUN pip3 install /container-local --upgrade --no-binary evo
+RUN pip3 install --ignore-installed /container-local --upgrade --no-binary evo
 RUN evo_config show --brief --no_color
 
 # Run tests.


### PR DESCRIPTION
Trying to deal with pip being stupid, aka saying things like
```
Requirement already satisfied, skipping upgrade: python-dateutil>=2.7 in /usr/lib/python3/dist-packages (from matplotlib->evo==1.19.0) (2.7.3)
```
directly followed by

```
ERROR: pandas 1.5.0 has requirement python-dateutil>=2.8.1, but you'll have python-dateutil 2.7.3 which is incompatible.
```