### PR TITLE
Add option to use reference for RPE pairs.

### DIFF
--- a/evo/core/metrics.py
+++ b/evo/core/metrics.py
@@ -180,7 +180,8 @@ class RPE(PE):
     def __init__(self,
                  pose_relation: PoseRelation = PoseRelation.translation_part,
                  delta: float = 1.0, delta_unit: Unit = Unit.frames,
-                 rel_delta_tol: float = 0.1, all_pairs: bool = False):
+                 rel_delta_tol: float = 0.1, all_pairs: bool = False,
+                 pairs_from_reference: bool = False):
         if delta < 0:
             raise MetricsException("delta must be a positive number")
         if delta_unit == Unit.frames and not isinstance(delta, int) \
@@ -192,6 +193,7 @@ class RPE(PE):
         self.rel_delta_tol = rel_delta_tol
         self.pose_relation = pose_relation
         self.all_pairs = all_pairs
+        self.pairs_from_reference = pairs_from_reference
         self.E: typing.List[np.ndarray] = []
         self.error = np.array([])
         self.delta_ids: typing.List[int] = []
@@ -250,9 +252,10 @@ class RPE(PE):
             raise MetricsException(
                 "trajectories must have same number of poses")
 
-        id_pairs = id_pairs_from_delta(traj_est.poses_se3, self.delta,
-                                       self.delta_unit, self.rel_delta_tol,
-                                       all_pairs=self.all_pairs)
+        id_pairs = id_pairs_from_delta(
+            (traj_ref.poses_se3
+             if self.pairs_from_reference else traj_est.poses_se3), self.delta,
+            self.delta_unit, self.rel_delta_tol, all_pairs=self.all_pairs)
 
         # Store flat id list e.g. for plotting.
         self.delta_ids = [j for i, j in id_pairs]

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -79,6 +79,9 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         help="use all pairs instead of consecutive pairs (disables plot)",
     )
+    algo_opts.add_argument(
+        "--pairs_from_reference", action="store_true",
+        help="determine the pose pairs from the reference trajectory")
 
     output_opts.add_argument(
         "-p",
@@ -202,8 +205,8 @@ def parser() -> argparse.ArgumentParser:
 def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
         pose_relation: metrics.PoseRelation, delta: float,
         delta_unit: metrics.Unit, rel_delta_tol: float = 0.1,
-        all_pairs: bool = False, align: bool = False,
-        correct_scale: bool = False, n_to_align: int = -1,
+        all_pairs: bool = False, pairs_from_reference: bool = False,
+        align: bool = False, correct_scale: bool = False, n_to_align: int = -1,
         align_origin: bool = False, ref_name: str = "reference",
         est_name: str = "estimate", support_loop: bool = False) -> Result:
 
@@ -222,7 +225,7 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
     logger.debug(SEP)
     data = (traj_ref, traj_est)
     rpe_metric = metrics.RPE(pose_relation, delta, delta_unit, rel_delta_tol,
-                             all_pairs)
+                             all_pairs, pairs_from_reference)
     rpe_metric.process_data(data)
 
     title = str(rpe_metric)
@@ -318,6 +321,7 @@ def run(args: argparse.Namespace) -> None:
         delta_unit=delta_unit,
         rel_delta_tol=args.delta_tol,
         all_pairs=args.all_pairs,
+        pairs_from_reference=args.pairs_from_reference,
         align=args.align,
         correct_scale=args.correct_scale,
         n_to_align=args.n_to_align,

--- a/test/cfg/ape_rpe/pairs_from_reference.json
+++ b/test/cfg/ape_rpe/pairs_from_reference.json
@@ -1,0 +1,11 @@
+{
+    "all_pairs": true,
+    "debug": true,
+    "delta": 1.0,
+    "delta_tol": 0.05,
+    "delta_unit": "m",
+    "pose_relation": "trans_part",
+    "pairs_from_reference": true,
+    "t_max_diff": 0.01,
+    "t_offset": 0.0
+}


### PR DESCRIPTION
Using the reference for the pairs is more consistent when doing multiple comparisons with different estimates.
To be backwards-compatible, the default is still the old behavior.

Closes: #483