### PR TITLE
Move alignment matrix to info part of results.

### DIFF
--- a/evo/main_ape.py
+++ b/evo/main_ape.py
@@ -97,8 +97,8 @@ def ape(traj_ref: PosePath3D, traj_est: PosePath3D,
         ape_result.add_np_array("distances", traj_est.distances)
 
     if alignment_transformation is not None:
-        ape_result.add_np_array("alignment_transformation_sim3",
-                                alignment_transformation)
+        ape_result.add_info(
+            {"alignment_transformation_sim3": alignment_transformation})
 
     return ape_result
 

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -115,8 +115,8 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
         rpe_result.add_np_array("distances", traj_est.distances[1:])
 
     if alignment_transformation is not None:
-        rpe_result.add_np_array("alignment_transformation_sim3",
-                                alignment_transformation)
+        rpe_result.add_info(
+            {"alignment_transformation_sim3": alignment_transformation})
 
     return rpe_result
 


### PR DESCRIPTION
Makes more sense because it is metadata and should not be used in result merging etc.