### PR TITLE
Add a pose relation option to suppress error along z-axis

### DIFF
--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -85,6 +85,8 @@ def get_pose_relation(args: argparse.Namespace) -> PoseRelation:
         pose_relation = PoseRelation.rotation_part
     elif args.pose_relation == "trans_part":
         pose_relation = PoseRelation.translation_part
+    elif args.pose_relation == "xy_trans_part":
+        pose_relation = PoseRelation.xy_translation_part
     elif args.pose_relation == "angle_deg":
         pose_relation = PoseRelation.rotation_angle_deg
     elif args.pose_relation == "angle_rad":

--- a/evo/main_ape_parser.py
+++ b/evo/main_ape_parser.py
@@ -16,8 +16,8 @@ def parser() -> argparse.ArgumentParser:
     algo_opts.add_argument(
         "-r", "--pose_relation", default="trans_part",
         help="pose relation on which the APE is based", choices=[
-            "full", "trans_part", "rot_part", "angle_deg", "angle_rad",
-            "point_distance"
+            "full", "trans_part", "xy_trans_part", "rot_part", "angle_deg",
+            "angle_rad", "point_distance"
         ])
     algo_opts.add_argument("-a", "--align",
                            help="alignment with Umeyama's method (no scale)",


### PR DESCRIPTION
As alluded to in my comment on #577, I have added a new pose relation option called `xy_trans_part` which suppresses error along the z-axis.