### PR TITLE
Unwarp angles before plotting them.

### DIFF
--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -628,8 +628,8 @@ def traj_rpy(axarr: np.ndarray, traj: trajectory.PosePath3D, style: str = '-',
         xlabel = "index"
     ylabels = ["$roll$ (deg)", "$pitch$ (deg)", "$yaw$ (deg)"]
     for i in range(0, 3):
-        axarr[i].plot(x, np.rad2deg(angles[:, i]), style, color=color,
-                      label=label, alpha=alpha)
+        axarr[i].plot(x, np.rad2deg(np.unwrap(angles[:, i])), style,
+                      color=color, label=label, alpha=alpha)
         axarr[i].set_ylabel(ylabels[i])
     axarr[2].set_xlabel(xlabel)
     if label:


### PR DESCRIPTION
Jumps in the angle plot make hard to compare different trajectory. In this commit we unwrap the angles before plotting them.

Before:
![hard_to_read](https://github.com/MichaelGrupp/evo/assets/18074378/46bc7cf8-abe7-4b6d-bdc5-7b10dc7b510e)


After:
![easier_to_read](https://github.com/MichaelGrupp/evo/assets/18074378/2def8c07-d2c1-4589-96f1-5b3f961d3441)
