### PR TITLE
Add feature to project trajectories to a 2D plane.

### DIFF
--- a/evo/core/trajectory.py
+++ b/evo/core/trajectory.py
@@ -204,14 +204,15 @@ class PosePath3D(object):
         if self._projected:
             raise TrajectoryException("path was already projected once")
         if plane == Plane.XY:
-            null_dim = 2
+            null_dim = 2  # Z
         elif plane == Plane.XZ:
-            null_dim = 1
+            null_dim = 1  # Y
         elif plane == Plane.YZ:
-            null_dim = 0
+            null_dim = 0  # X
         else:
             raise TrajectoryException(f"unknown projection plane {plane}")
 
+        # Project poses and rotations (forcing to angle around normal).
         rotation_axis = np.zeros(3)
         rotation_axis[null_dim] = 1
         for pose in self.poses_se3:
@@ -220,7 +221,7 @@ class PosePath3D(object):
                 pose[:3, :3], "sxyz")[null_dim]
             pose[:3, :3] = lie.so3_exp(angle_axis)
 
-        # Flush private data that will be regenerated on demand via @property.
+        # Flush cached data that will be regenerated on demand via @property.
         if hasattr(self, "_positions_xyz"):
             del self._positions_xyz
         if hasattr(self, "_orientations_quat_wxyz"):

--- a/evo/core/trajectory.py
+++ b/evo/core/trajectory.py
@@ -38,10 +38,13 @@ class TrajectoryException(EvoException):
 
 
 @unique
-class ProjectionPlane(Enum):
-    xy = "xy"
-    xz = "xz"
-    yz = "yz"
+class Plane(Enum):
+    """
+    Planes embedded in R3, e.g. for projection purposes.
+    """
+    XY = "xy"
+    XZ = "xz"
+    YZ = "yz"
 
 
 class PosePath3D(object):
@@ -193,18 +196,18 @@ class PosePath3D(object):
         if hasattr(self, "_positions_xyz"):
             self._positions_xyz = s * self._positions_xyz
 
-    def project(self, plane: ProjectionPlane) -> None:
+    def project(self, plane: Plane) -> None:
         """
         Projects the positions and orientations of the path into a plane.
-        :param plane: desired plane into which the positions will be projected
+        :param plane: desired plane into which the poses will be projected
         """
         if self._projected:
             raise TrajectoryException("path was already projected once")
-        if plane == ProjectionPlane.xy:
+        if plane == Plane.XY:
             null_dim = 2
-        elif plane == ProjectionPlane.xz:
+        elif plane == Plane.XZ:
             null_dim = 1
-        elif plane == ProjectionPlane.yz:
+        elif plane == Plane.YZ:
             null_dim = 0
         else:
             raise TrajectoryException(f"unknown projection plane {plane}")

--- a/evo/main_ape.py
+++ b/evo/main_ape.py
@@ -30,7 +30,7 @@ import numpy as np
 import evo.common_ape_rpe as common
 from evo.core import lie_algebra, sync, metrics
 from evo.core.result import Result
-from evo.core.trajectory import PosePath3D, PoseTrajectory3D, ProjectionPlane
+from evo.core.trajectory import PosePath3D, PoseTrajectory3D, Plane
 from evo.tools import file_interface, log
 from evo.tools.settings import SETTINGS
 
@@ -45,7 +45,7 @@ def ape(traj_ref: PosePath3D, traj_est: PosePath3D,
         align_origin: bool = False, ref_name: str = "reference",
         est_name: str = "estimate",
         change_unit: typing.Optional[metrics.Unit] = None,
-        project_to_plane: typing.Optional[ProjectionPlane] = None) -> Result:
+        project_to_plane: typing.Optional[Plane] = None) -> Result:
 
     # Align the trajectories.
     only_scale = correct_scale and not align
@@ -61,8 +61,8 @@ def ape(traj_ref: PosePath3D, traj_est: PosePath3D,
     # Projection is done after potential 3D alignment & transformation steps.
     if project_to_plane:
         logger.debug(SEP)
-        logger.debug(
-            f"Projecting trajectories to {project_to_plane.value} plane.")
+        logger.debug("Projecting trajectories to %s plane.",
+                     project_to_plane.value)
         traj_ref.project(project_to_plane)
         traj_est.project(project_to_plane)
 
@@ -147,8 +147,7 @@ def run(args: argparse.Namespace) -> None:
 
     pose_relation = common.get_pose_relation(args)
     change_unit = metrics.Unit(args.change_unit) if args.change_unit else None
-    plane = ProjectionPlane(
-        args.project_to_plane) if args.project_to_plane else None
+    plane = Plane(args.project_to_plane) if args.project_to_plane else None
 
     result = ape(traj_ref=traj_ref, traj_est=traj_est,
                  pose_relation=pose_relation, align=args.align,

--- a/evo/main_ape.py
+++ b/evo/main_ape.py
@@ -30,7 +30,7 @@ import numpy as np
 import evo.common_ape_rpe as common
 from evo.core import lie_algebra, sync, metrics
 from evo.core.result import Result
-from evo.core.trajectory import PosePath3D, PoseTrajectory3D
+from evo.core.trajectory import PosePath3D, PoseTrajectory3D, ProjectionPlane
 from evo.tools import file_interface, log
 from evo.tools.settings import SETTINGS
 
@@ -44,7 +44,8 @@ def ape(traj_ref: PosePath3D, traj_est: PosePath3D,
         correct_scale: bool = False, n_to_align: int = -1,
         align_origin: bool = False, ref_name: str = "reference",
         est_name: str = "estimate",
-        change_unit: typing.Optional[metrics.Unit] = None) -> Result:
+        change_unit: typing.Optional[metrics.Unit] = None,
+        project_to_plane: typing.Optional[ProjectionPlane] = None) -> Result:
 
     # Align the trajectories.
     only_scale = correct_scale and not align
@@ -56,6 +57,13 @@ def ape(traj_ref: PosePath3D, traj_est: PosePath3D,
     elif align_origin:
         logger.debug(SEP)
         alignment_transformation = traj_est.align_origin(traj_ref)
+
+    # Projection is done after potential 3D alignment & transformation steps.
+    if project_to_plane:
+        logger.debug(SEP)
+        logger.debug(f"Projecting trajectories to {project_to_plane} plane.")
+        traj_ref.project(project_to_plane)
+        traj_est.project(project_to_plane)
 
     # Calculate APE.
     logger.debug(SEP)
@@ -135,12 +143,15 @@ def run(args: argparse.Namespace) -> None:
 
     pose_relation = common.get_pose_relation(args)
     change_unit = metrics.Unit(args.change_unit) if args.change_unit else None
+    plane = ProjectionPlane(
+        args.project_to_plane) if args.project_to_plane else None
 
     result = ape(traj_ref=traj_ref, traj_est=traj_est,
                  pose_relation=pose_relation, align=args.align,
                  correct_scale=args.correct_scale, n_to_align=args.n_to_align,
                  align_origin=args.align_origin, ref_name=ref_name,
-                 est_name=est_name, change_unit=change_unit)
+                 est_name=est_name, change_unit=change_unit,
+                 project_to_plane=plane)
 
     if args.plot or args.save_plot or args.serialize_plot:
         common.plot_result(args, result, traj_ref,

--- a/evo/main_ape.py
+++ b/evo/main_ape.py
@@ -89,6 +89,9 @@ def ape(traj_ref: PosePath3D, traj_est: PosePath3D,
     if (align or correct_scale) and n_to_align != -1:
         title += " (aligned poses: {})".format(n_to_align)
 
+    if project_to_plane:
+        title += f"\n(projected to {project_to_plane.value} plane)"
+
     ape_result = ape_metric.get_result(ref_name, est_name)
     ape_result.info["title"] = title
 

--- a/evo/main_ape.py
+++ b/evo/main_ape.py
@@ -61,7 +61,8 @@ def ape(traj_ref: PosePath3D, traj_est: PosePath3D,
     # Projection is done after potential 3D alignment & transformation steps.
     if project_to_plane:
         logger.debug(SEP)
-        logger.debug(f"Projecting trajectories to {project_to_plane} plane.")
+        logger.debug(
+            f"Projecting trajectories to {project_to_plane.value} plane.")
         traj_ref.project(project_to_plane)
         traj_est.project(project_to_plane)
 

--- a/evo/main_ape_parser.py
+++ b/evo/main_ape_parser.py
@@ -36,6 +36,10 @@ def parser() -> argparse.ArgumentParser:
         "--change_unit", default=None,
         choices=[u.value for u in (units.ANGLE_UNITS + units.LENGTH_UNITS)],
         help="Changes the output unit of the metric, if possible.")
+    algo_opts.add_argument(
+        "--project_to_plane", type=str, choices=["xy", "xz", "yz"],
+        help="Projects the trajectories to 2D in the desired plane. "
+        "This is done after potential 3D alignment & transformation steps.")
 
     output_opts.add_argument(
         "-p",

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -30,7 +30,7 @@ import numpy as np
 import evo.common_ape_rpe as common
 from evo.core import lie_algebra, sync, metrics
 from evo.core.result import Result
-from evo.core.trajectory import PosePath3D, PoseTrajectory3D, ProjectionPlane
+from evo.core.trajectory import PosePath3D, PoseTrajectory3D, Plane
 from evo.tools import file_interface, log
 from evo.tools.settings import SETTINGS
 
@@ -47,7 +47,7 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
         align_origin: bool = False, ref_name: str = "reference",
         est_name: str = "estimate", support_loop: bool = False,
         change_unit: typing.Optional[metrics.Unit] = None,
-        project_to_plane: typing.Optional[ProjectionPlane] = None) -> Result:
+        project_to_plane: typing.Optional[Plane] = None) -> Result:
 
     # Align the trajectories.
     only_scale = correct_scale and not align
@@ -63,8 +63,8 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
     # Projection is done after potential 3D alignment & transformation steps.
     if project_to_plane:
         logger.debug(SEP)
-        logger.debug(
-            f"Projecting trajectories to {project_to_plane.value} plane.")
+        logger.debug("Projecting trajectories to %s plane.",
+                     project_to_plane.value)
         traj_ref.project(project_to_plane)
         traj_est.project(project_to_plane)
 
@@ -147,8 +147,7 @@ def run(args: argparse.Namespace) -> None:
     pose_relation = common.get_pose_relation(args)
     delta_unit = common.get_delta_unit(args)
     change_unit = metrics.Unit(args.change_unit) if args.change_unit else None
-    plane = ProjectionPlane(
-        args.project_to_plane) if args.project_to_plane else None
+    plane = Plane(args.project_to_plane) if args.project_to_plane else None
 
     traj_ref_full = None
     if args.plot_full_ref:

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -63,7 +63,8 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
     # Projection is done after potential 3D alignment & transformation steps.
     if project_to_plane:
         logger.debug(SEP)
-        logger.debug(f"Projecting trajectories to {project_to_plane} plane.")
+        logger.debug(
+            f"Projecting trajectories to {project_to_plane.value} plane.")
         traj_ref.project(project_to_plane)
         traj_est.project(project_to_plane)
 

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -92,6 +92,9 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
     if (align or correct_scale) and n_to_align != -1:
         title += " (aligned poses: {})".format(n_to_align)
 
+    if project_to_plane:
+        title += f"\n(projected to {project_to_plane.value} plane)"
+
     rpe_result = rpe_metric.get_result(ref_name, est_name)
     rpe_result.info["title"] = title
     logger.debug(SEP)

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -30,7 +30,7 @@ import numpy as np
 import evo.common_ape_rpe as common
 from evo.core import lie_algebra, sync, metrics
 from evo.core.result import Result
-from evo.core.trajectory import PosePath3D, PoseTrajectory3D
+from evo.core.trajectory import PosePath3D, PoseTrajectory3D, ProjectionPlane
 from evo.tools import file_interface, log
 from evo.tools.settings import SETTINGS
 
@@ -46,7 +46,8 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
         align: bool = False, correct_scale: bool = False, n_to_align: int = -1,
         align_origin: bool = False, ref_name: str = "reference",
         est_name: str = "estimate", support_loop: bool = False,
-        change_unit: typing.Optional[metrics.Unit] = None) -> Result:
+        change_unit: typing.Optional[metrics.Unit] = None,
+        project_to_plane: typing.Optional[ProjectionPlane] = None) -> Result:
 
     # Align the trajectories.
     only_scale = correct_scale and not align
@@ -58,6 +59,13 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
     elif align_origin:
         logger.debug(SEP)
         alignment_transformation = traj_est.align_origin(traj_ref)
+
+    # Projection is done after potential 3D alignment & transformation steps.
+    if project_to_plane:
+        logger.debug(SEP)
+        logger.debug(f"Projecting trajectories to {project_to_plane} plane.")
+        traj_ref.project(project_to_plane)
+        traj_est.project(project_to_plane)
 
     # Calculate RPE.
     logger.debug(SEP)
@@ -135,6 +143,8 @@ def run(args: argparse.Namespace) -> None:
     pose_relation = common.get_pose_relation(args)
     delta_unit = common.get_delta_unit(args)
     change_unit = metrics.Unit(args.change_unit) if args.change_unit else None
+    plane = ProjectionPlane(
+        args.project_to_plane) if args.project_to_plane else None
 
     traj_ref_full = None
     if args.plot_full_ref:
@@ -162,7 +172,8 @@ def run(args: argparse.Namespace) -> None:
                  pairs_from_reference=args.pairs_from_reference,
                  align=args.align, correct_scale=args.correct_scale,
                  n_to_align=args.n_to_align, align_origin=args.align_origin,
-                 ref_name=ref_name, est_name=est_name, change_unit=change_unit)
+                 ref_name=ref_name, est_name=est_name, change_unit=change_unit,
+                 project_to_plane=plane)
 
     if args.plot or args.save_plot or args.serialize_plot:
         common.plot_result(args, result, traj_ref,

--- a/evo/main_rpe_parser.py
+++ b/evo/main_rpe_parser.py
@@ -52,6 +52,9 @@ def parser() -> argparse.ArgumentParser:
         "--change_unit", default=None,
         choices=[u.value for u in (units.ANGLE_UNITS + units.LENGTH_UNITS)],
         help="Changes the output unit of the metric, if possible.")
+    algo_opts.add_argument(
+        "--project_to_plane", type=str, choices=["xy", "xz", "yz"],
+        help="Projects the trajectories to 2D in the desired plane.")
 
     output_opts.add_argument(
         "-p",

--- a/evo/main_traj.py
+++ b/evo/main_traj.py
@@ -265,9 +265,9 @@ def run(args):
 
     # Note: projection is done after potential alignment & transformation steps.
     if args.project_to_plane:
-        plane = trajectory.ProjectionPlane(args.project_to_plane)
+        plane = trajectory.Plane(args.project_to_plane)
         logger.debug(SEP)
-        logger.debug(f"Projecting trajectories to {plane.value} plane.")
+        logger.debug("Projecting trajectories to %s plane.", plane.value)
         for traj in trajectories.values():
             traj.project(plane)
         if ref_traj:

--- a/evo/main_traj.py
+++ b/evo/main_traj.py
@@ -263,6 +263,16 @@ def run(args):
             traj.transform(transform, right_mul=args.transform_right,
                            propagate=args.propagate_transform)
 
+    # Note: projection is done after potential alignment & transformation steps.
+    if args.project_to_plane:
+        plane = trajectory.ProjectionPlane(args.project_to_plane)
+        logger.debug(SEP)
+        logger.debug(f"Projecting trajectories to {plane.value} plane.")
+        for traj in trajectories.values():
+            traj.project(plane)
+        if ref_traj:
+            ref_traj.project(plane)
+
     for name, traj in trajectories.items():
         print_traj_info(to_compact_name(name, args), traj, args.verbose,
                         args.full_check)

--- a/evo/main_traj_parser.py
+++ b/evo/main_traj_parser.py
@@ -56,6 +56,10 @@ def parser() -> argparse.ArgumentParser:
     algo_opts.add_argument(
         "--merge", help="merge the trajectories in a single trajectory",
         action="store_true")
+    algo_opts.add_argument(
+        "--project_to_plane", type=str, choices=["xy", "xz", "yz"],
+        help="Projects the trajectories to 2D in the desired plane. "
+        "This is done after potential 3D alignment & transformation steps.")
     output_opts.add_argument("-p", "--plot", help="show plot window",
                              action="store_true")
     output_opts.add_argument(

--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -27,6 +27,7 @@ import itertools
 import logging
 import pickle
 import typing
+import warnings
 from enum import Enum, unique
 
 import numpy as np
@@ -464,8 +465,11 @@ def traj_colormap(ax: Axes, traj: trajectory.PosePath3D, array: ListOrArray,
     ax.add_collection(line_collection)
     ax.autoscale_view(True, True, True)
     if plot_mode == PlotMode.xyz and isinstance(ax, Axes3D):
-        ax.set_zlim(np.amin(traj.positions_xyz[:, 2]),
-                    np.amax(traj.positions_xyz[:, 2]))
+        min_z = np.amin(traj.positions_xyz[:, 2])
+        max_z = np.amax(traj.positions_xyz[:, 2])                
+        # Only adjust limits if there are z values to suppress mpl warning.
+        if min_z != max_z:
+            ax.set_zlim(min_z, max_z)
     if SETTINGS.plot_xyz_realistic:
         set_aspect_equal(ax)
     if fig is None:

--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -27,7 +27,6 @@ import itertools
 import logging
 import pickle
 import typing
-import warnings
 from enum import Enum, unique
 
 import numpy as np

--- a/test/test_trajectory.py
+++ b/test/test_trajectory.py
@@ -151,11 +151,24 @@ class TestPosePath3D(unittest.TestCase):
             angle = path.get_orientations_euler("sxyz")[0][null_dim]
 
             path.project(plane)
+            # Position value has to be zero outside of the plane.
             self.assertEqual(path.poses_se3[0][null_dim][3], 0)
             self.assertEqual(path.positions_xyz[0][null_dim], 0)
+            # Rotation has to be angle around the nulled dimension's axis.
             self.assertTrue(
                 np.allclose(lie.so3_log(lie.so3_from_se3(path.poses_se3[0])),
                             angle * axis))
+            # Quaternion has to be zero around the plane's basis vectors.
+            quat_wxyz = path.orientations_quat_wxyz[0]
+            if plane == trajectory.ProjectionPlane.xy:
+                self.assertAlmostEqual(quat_wxyz[1], 0)  # x
+                self.assertAlmostEqual(quat_wxyz[2], 0)  # y
+            elif plane == trajectory.ProjectionPlane.xz:
+                self.assertAlmostEqual(quat_wxyz[1], 0)  # x
+                self.assertAlmostEqual(quat_wxyz[3], 0)  # z
+            elif plane == trajectory.ProjectionPlane.yz:
+                self.assertAlmostEqual(quat_wxyz[2], 0)  # y
+                self.assertAlmostEqual(quat_wxyz[3], 0)  # z
 
 
 class TestPoseTrajectory3D(unittest.TestCase):

--- a/test/test_trajectory.py
+++ b/test/test_trajectory.py
@@ -143,6 +143,20 @@ class TestPosePath3D(unittest.TestCase):
         self.assertEqual(path.distances.size, path.num_poses)
         self.assertAlmostEqual(path.distances[-1], path.path_length)
 
+    def test_projection(self):
+        for plane, null_dim in zip(trajectory.ProjectionPlane, [2, 1, 0]):
+            path = helpers.fake_path(length=1)
+            axis = np.zeros(3)
+            axis[null_dim] = 1
+            angle = path.get_orientations_euler("sxyz")[0][null_dim]
+
+            path.project(plane)
+            self.assertEqual(path.poses_se3[0][null_dim][3], 0)
+            self.assertEqual(path.positions_xyz[0][null_dim], 0)
+            self.assertTrue(
+                np.allclose(lie.so3_log(lie.so3_from_se3(path.poses_se3[0])),
+                            angle * axis))
+
 
 class TestPoseTrajectory3D(unittest.TestCase):
     def test_equals(self):

--- a/test/test_trajectory.py
+++ b/test/test_trajectory.py
@@ -144,7 +144,10 @@ class TestPosePath3D(unittest.TestCase):
         self.assertAlmostEqual(path.distances[-1], path.path_length)
 
     def test_projection(self):
-        for plane, null_dim in zip(trajectory.ProjectionPlane, [2, 1, 0]):
+        """
+        Checks that projection into a plane modifies the poses correctly.
+        """
+        for plane, null_dim in zip(trajectory.Plane, [2, 1, 0]):
             path = helpers.fake_path(length=1)
             axis = np.zeros(3)
             axis[null_dim] = 1
@@ -160,13 +163,13 @@ class TestPosePath3D(unittest.TestCase):
                             angle * axis))
             # Quaternion has to be zero around the plane's basis vectors.
             quat_wxyz = path.orientations_quat_wxyz[0]
-            if plane == trajectory.ProjectionPlane.xy:
+            if plane == trajectory.Plane.XY:
                 self.assertAlmostEqual(quat_wxyz[1], 0)  # x
                 self.assertAlmostEqual(quat_wxyz[2], 0)  # y
-            elif plane == trajectory.ProjectionPlane.xz:
+            elif plane == trajectory.Plane.XZ:
                 self.assertAlmostEqual(quat_wxyz[1], 0)  # x
                 self.assertAlmostEqual(quat_wxyz[3], 0)  # z
-            elif plane == trajectory.ProjectionPlane.yz:
+            elif plane == trajectory.Plane.YZ:
                 self.assertAlmostEqual(quat_wxyz[2], 0)  # y
                 self.assertAlmostEqual(quat_wxyz[3], 0)  # z
 


### PR DESCRIPTION
Adds a flag `--project_to_plane` for xy, xz and yz plane projection. Projection is done after alignment steps.

Example: `evo_ape tum a b --project_to_plane xz`