### PR TITLE
Fix timestamp based index for raw plot in evo_res

### DIFF
--- a/evo/main_res.py
+++ b/evo/main_res.py
@@ -106,6 +106,7 @@ def run(args: argparse.Namespace) -> None:
                     "keeping only first occurrence of duplicates".format(key))
                 new_error_df = new_error_df[~duplicates]  # type: ignore
             error_df = pd.concat([error_df, new_error_df], axis=1)
+        error_df.sort_index(inplace=True)
 
     # check titles
     if args.ignore_title:


### PR DESCRIPTION
Otherwise there can be jumps in the line plot if the results don't have the same timestamp order.

See issue #670.