### PR TITLE
Limit evo_res --verbose column content

### DIFF
--- a/evo/main_res.py
+++ b/evo/main_res.py
@@ -132,8 +132,8 @@ def run(args: argparse.Namespace) -> None:
                     sys.exit()
 
     logger.debug(SEP)
-    logger.debug("Aggregated dataframe:\n{}".format(
-        df.to_string(line_width=80)))
+    logger.debug("Aggregated dataframe:\n%s",
+                 df.to_string(line_width=80, max_colwidth=40))
 
     # show a statistics overview
     logger.debug(SEP)


### PR DESCRIPTION
Less spam on stdout by raw value arrays. The output is just to provide a small overview.