### PR TITLE
[#679] Bugfix: read_tum function called when reading euroc format

### DIFF
--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -51,7 +51,7 @@ def load_trajectories(
         ref_name, est_name = args.ref_file, args.est_file
     elif args.subcommand == "euroc":
         traj_ref = file_interface.read_euroc_csv_trajectory(args.state_gt_csv)
-        traj_est = file_interface.read_tum_trajectory_file(args.est_file)
+        traj_est = file_interface.read_euroc_csv_trajectory(args.est_file)
         ref_name, est_name = args.state_gt_csv, args.est_file
     elif args.subcommand in ("bag", "bag2"):
         logger.debug("Opening bag file " + args.bag)


### PR DESCRIPTION
Simple bugfix for running ape/rpe with euroc data