### PR TITLE
Improve interplay of alignment flags

### DIFF
--- a/evo/main_ape.py
+++ b/evo/main_ape.py
@@ -28,7 +28,6 @@ import typing
 import numpy as np
 
 import evo.common_ape_rpe as common
-from evo import EvoException
 from evo.core import lie_algebra, sync, metrics
 from evo.core.result import Result
 from evo.core.trajectory import PosePath3D, PoseTrajectory3D, Plane
@@ -47,9 +46,6 @@ def ape(traj_ref: PosePath3D, traj_est: PosePath3D,
         est_name: str = "estimate",
         change_unit: typing.Optional[metrics.Unit] = None,
         project_to_plane: typing.Optional[Plane] = None) -> Result:
-    if align_origin and align:
-        raise EvoException(
-            "origin and Umeyama alignment can't be used together")
 
     # Align the trajectories.
     only_scale = correct_scale and not align

--- a/evo/main_ape_parser.py
+++ b/evo/main_ape_parser.py
@@ -19,19 +19,12 @@ def parser() -> argparse.ArgumentParser:
             "full", "trans_part", "rot_part", "angle_deg", "angle_rad",
             "point_distance"
         ])
-    algo_opts.add_argument("-a", "--align",
-                           help="alignment with Umeyama's method (no scale)",
-                           action="store_true")
     algo_opts.add_argument("-s", "--correct_scale", action="store_true",
                            help="correct scale with Umeyama's method")
     algo_opts.add_argument(
         "--n_to_align",
         help="the number of poses to use for Umeyama alignment, "
         "counted from the start (default: all)", default=-1, type=int)
-    algo_opts.add_argument(
-        "--align_origin",
-        help="align the trajectory origin to the origin of the reference "
-        "trajectory", action="store_true")
     algo_opts.add_argument(
         "--change_unit", default=None,
         choices=[u.value for u in (units.ANGLE_UNITS + units.LENGTH_UNITS)],
@@ -48,6 +41,15 @@ def parser() -> argparse.ArgumentParser:
         help="Filters out poses if the distance or angle to the previous one "
         " is below the threshold distance or angle. "
         "Angle is expected in degrees.")
+
+    align_opts = algo_opts.add_mutually_exclusive_group()
+    align_opts.add_argument("-a", "--align",
+                            help="alignment with Umeyama's method (no scale)",
+                            action="store_true")
+    align_opts.add_argument(
+        "--align_origin",
+        help="align the trajectory origin to the origin of the reference "
+        "trajectory", action="store_true")
 
     output_opts.add_argument(
         "-p",

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -28,7 +28,6 @@ import typing
 import numpy as np
 
 import evo.common_ape_rpe as common
-from evo import EvoException
 from evo.core import lie_algebra, sync, metrics
 from evo.core.result import Result
 from evo.core.trajectory import PosePath3D, PoseTrajectory3D, Plane
@@ -49,9 +48,6 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
         est_name: str = "estimate", support_loop: bool = False,
         change_unit: typing.Optional[metrics.Unit] = None,
         project_to_plane: typing.Optional[Plane] = None) -> Result:
-    if align_origin and align:
-        raise EvoException(
-            "origin and Umeyama alignment can't be used together")
 
     # Align the trajectories.
     only_scale = correct_scale and not align

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -28,6 +28,7 @@ import typing
 import numpy as np
 
 import evo.common_ape_rpe as common
+from evo import EvoException
 from evo.core import lie_algebra, sync, metrics
 from evo.core.result import Result
 from evo.core.trajectory import PosePath3D, PoseTrajectory3D, Plane
@@ -48,6 +49,9 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
         est_name: str = "estimate", support_loop: bool = False,
         change_unit: typing.Optional[metrics.Unit] = None,
         project_to_plane: typing.Optional[Plane] = None) -> Result:
+    if align_origin and align:
+        raise EvoException(
+            "origin and Umeyama alignment can't be used together")
 
     # Align the trajectories.
     only_scale = correct_scale and not align
@@ -56,7 +60,7 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
         logger.debug(SEP)
         alignment_transformation = lie_algebra.sim3(
             *traj_est.align(traj_ref, correct_scale, only_scale, n=n_to_align))
-    elif align_origin:
+    if align_origin:
         logger.debug(SEP)
         alignment_transformation = traj_est.align_origin(traj_ref)
 
@@ -85,12 +89,12 @@ def rpe(traj_ref: PosePath3D, traj_est: PosePath3D,
         title += "\n(with Sim(3) Umeyama alignment)"
     elif only_scale:
         title += "\n(scale corrected)"
-    elif align_origin:
-        title += "\n(with origin alignment)"
-    else:
+    elif not align_origin:
         title += "\n(not aligned)"
     if (align or correct_scale) and n_to_align != -1:
         title += " (aligned poses: {})".format(n_to_align)
+    if align_origin:
+        title += "\n(with origin alignment)"
 
     if project_to_plane:
         title += f"\n(projected to {project_to_plane.value} plane)"

--- a/evo/main_rpe_parser.py
+++ b/evo/main_rpe_parser.py
@@ -19,19 +19,12 @@ def parser() -> argparse.ArgumentParser:
             "full", "trans_part", "rot_part", "angle_deg", "angle_rad",
             "point_distance", "point_distance_error_ratio"
         ])
-    algo_opts.add_argument("-a", "--align",
-                           help="alignment with Umeyama's method (no scale)",
-                           action="store_true")
     algo_opts.add_argument("-s", "--correct_scale", action="store_true",
                            help="correct scale with Umeyama's method")
     algo_opts.add_argument(
         "--n_to_align",
         help="the number of poses to use for Umeyama alignment, "
         "counted from the start (default: all)", default=-1, type=int)
-    algo_opts.add_argument(
-        "--align_origin",
-        help="align the trajectory origin to the origin of the reference "
-        "trajectory", action="store_true")
     algo_opts.add_argument("-d", "--delta", type=float, default=1,
                            help="delta between relative poses")
     algo_opts.add_argument("-t", "--delta_tol", type=float, default=0.1,
@@ -63,6 +56,15 @@ def parser() -> argparse.ArgumentParser:
         help="Filters out poses if the distance or angle to the previous one "
         " is below the threshold distance or angle. "
         "Angle is expected in degrees.")
+
+    align_opts = algo_opts.add_mutually_exclusive_group()
+    align_opts.add_argument("-a", "--align",
+                            help="alignment with Umeyama's method (no scale)",
+                            action="store_true")
+    align_opts.add_argument(
+        "--align_origin",
+        help="align the trajectory origin to the origin of the reference "
+        "trajectory", action="store_true")
 
     output_opts.add_argument(
         "-p",

--- a/evo/main_traj.py
+++ b/evo/main_traj.py
@@ -235,6 +235,8 @@ def run(args):
 
     if args.n_to_align != -1 and not (args.align or args.correct_scale):
         die("--n_to_align is useless without --align or/and --correct_scale")
+    if args.align and args.align_origin:
+        die("origin and Umeyama alignment can't be used together")
 
     # TODO: this is fugly, but is a quick solution for remembering each synced
     # reference when plotting pose correspondences later...

--- a/evo/main_traj.py
+++ b/evo/main_traj.py
@@ -235,8 +235,6 @@ def run(args):
 
     if args.n_to_align != -1 and not (args.align or args.correct_scale):
         die("--n_to_align is useless without --align or/and --correct_scale")
-    if args.align and args.align_origin:
-        die("origin and Umeyama alignment can't be used together")
 
     # TODO: this is fugly, but is a quick solution for remembering each synced
     # reference when plotting pose correspondences later...

--- a/evo/main_traj_parser.py
+++ b/evo/main_traj_parser.py
@@ -14,19 +14,12 @@ def parser() -> argparse.ArgumentParser:
                                help="run all checks and print all stats",
                                action="store_true")
     algo_opts.add_argument(
-        "-a", "--align", help="alignment with Umeyama's method (no scale)"
-        " - requires --ref", action="store_true")
-    algo_opts.add_argument(
         "-s", "--correct_scale", help="scale correction with Umeyama's method"
         " - requires --ref", action="store_true")
     algo_opts.add_argument(
         "--n_to_align",
         help="the number of poses to use for Umeyama alignment, "
         "counted from the start (default: all)", default=-1, type=int)
-    algo_opts.add_argument(
-        "--align_origin",
-        help="align the trajectory origin to the origin of the reference "
-        "trajectory", action="store_true")
     algo_opts.add_argument(
         "--sync",
         help="associate trajectories via matching timestamps - requires --ref",
@@ -68,6 +61,16 @@ def parser() -> argparse.ArgumentParser:
         help="Filters out poses if the distance or angle to the previous one "
         " is below the threshold distance or angle. "
         "Angle is expected in degrees.")
+
+    align_opts = algo_opts.add_mutually_exclusive_group()
+    align_opts.add_argument("-a", "--align",
+                            help="alignment with Umeyama's method (no scale)",
+                            action="store_true")
+    align_opts.add_argument(
+        "--align_origin",
+        help="align the trajectory origin to the origin of the reference "
+        "trajectory", action="store_true")
+
     output_opts.add_argument("-p", "--plot", help="show plot window",
                              action="store_true")
     output_opts.add_argument(


### PR DESCRIPTION
- Allow scale correction together with origin alignment.
- Handle strictly that `--align` and `--align_origin` shall be used mutually exclusive.

Relates to issue #693 