### PR TITLE
Save figures with tight bbox

### DIFF
--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -78,7 +78,8 @@ def apply_settings(settings: SettingsContainer = SETTINGS):
         # https://matplotlib.org/stable/users/explain/axes/constrainedlayout_guide.html
         "figure.constrained_layout.use": True,
         "font.family": settings.plot_fontfamily,
-        "pgf.texsystem": settings.plot_texsystem
+        "pgf.texsystem": settings.plot_texsystem,
+        "savefig.bbox": "tight",
     })
     if "xkcd" in settings:
         plt.xkcd()


### PR DESCRIPTION
Fits the image bbox to the content to avoid unnecessary blank space.
Enabled globally to work with `--save_plot` and with the save button
of the matplotlib Qt / Tk GUI canvas.

Closes #701 