### PR TITLE
Set default zoom of 3D axis to avoid clipping in savefig

### DIFF
--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -299,6 +299,9 @@ def prepare_axis(fig: Figure, plot_mode: PlotMode = PlotMode.xy,
 
     if plot_mode == PlotMode.xyz:
         ax = fig.add_subplot(subplot_arg, projection="3d")
+        # Zoom out a bit. This value is arbitrary, but without it the axis
+        # labels can get cut off due to constrained_layout. See issue #718.
+        ax.set_box_aspect(None, zoom=0.9)
     else:
         ax = fig.add_subplot(subplot_arg)
     if plot_mode in {PlotMode.xy, PlotMode.xz, PlotMode.xyz}:

--- a/evo/tools/plot.py
+++ b/evo/tools/plot.py
@@ -298,10 +298,9 @@ def prepare_axis(fig: Figure, plot_mode: PlotMode = PlotMode.xy,
         raise PlotException(f"{length_unit} is not a length unit")
 
     if plot_mode == PlotMode.xyz:
-        ax = fig.add_subplot(subplot_arg, projection="3d")
-        # Zoom out a bit. This value is arbitrary, but without it the axis
-        # labels can get cut off due to constrained_layout. See issue #718.
-        ax.set_box_aspect(None, zoom=0.9)
+        ax: Axes3D = fig.add_subplot(subplot_arg, projection="3d")
+        # Zoom can help against clipping labels. See issue #718.
+        ax.set_box_aspect(None, zoom=SETTINGS.plot_3d_zoom)
     else:
         ax = fig.add_subplot(subplot_arg)
     if plot_mode in {PlotMode.xy, PlotMode.xz, PlotMode.xyz}:

--- a/evo/tools/settings_template.py
+++ b/evo/tools/settings_template.py
@@ -64,6 +64,10 @@ DEFAULT_SETTINGS_DICT_DOC = {
         "",
         "API token for the map_tile_provider, if required."
     ),
+    "plot_3d_zoom": (
+        0.9,
+        "Default zoom factor for 3D plots. Can be used to avoid clipping labels."
+    ),
     "plot_axis_marker_scale": (
         0.,
         "Scaling parameter of pose coordinate frame markers. 0 will draw nothing."


### PR DESCRIPTION
This allows to keep the constrained layout (PR #703), which unfortunately is a bit broken with 3D plots...

Might need to be adjusted for small figure sizes, large font sizes etc.

See issue #718.