### PR TITLE
Allow to cache TF per bag path, not per reader object

### DIFF
--- a/evo/tools/file_interface.py
+++ b/evo/tools/file_interface.py
@@ -258,9 +258,11 @@ def get_supported_topics(
     ])
 
 
-def read_bag_trajectory(reader: typing.Union[Rosbag1Reader,
-                                             Rosbag2Reader], topic: str,
-                        cache_tf_tree: bool = False) -> PoseTrajectory3D:
+def read_bag_trajectory(
+    reader: typing.Union[Rosbag1Reader, Rosbag2Reader], topic: str,
+    cache_tf_tree: bool = False,
+    cache_hash_source: tf_id.HashSource = tf_id.HashSource.READER_INSTANCE
+) -> PoseTrajectory3D:
     """
     :param reader: opened bag reader (rosbags.rosbag2 or rosbags.rosbag1)
     :param topic: trajectory topic of supported message type,
@@ -268,6 +270,8 @@ def read_bag_trajectory(reader: typing.Union[Rosbag1Reader,
     :param cache_tf_tree: cache the tf tree. This speeds up the trajectory
                   reading in case multiple TF trajectories are loaded from
                   the same reader.
+    :param cache_hash_source: Determines whether to cache per reader instance
+        (default) or per bag filename (e.g. if a bag is opened multiple times).
     :return: trajectory.PoseTrajectory3D
     """
     if not isinstance(reader, (Rosbag1Reader, Rosbag2Reader)):
@@ -279,7 +283,8 @@ def read_bag_trajectory(reader: typing.Union[Rosbag1Reader,
     if tf_id.check_id(topic):
         # Use TfCache instead if it's a TF transform ID.
         from evo.tools import tf_cache
-        tf_tree_cache = (tf_cache.instance(reader.__hash__())
+        tf_tree_cache = (tf_cache.instance(
+            tf_id.hash_bag(reader, cache_hash_source))
                          if cache_tf_tree else tf_cache.TfCache())
         return tf_tree_cache.get_trajectory(reader, identifier=topic)
 

--- a/evo/tools/tf_id.py
+++ b/evo/tools/tf_id.py
@@ -18,7 +18,12 @@ You should have received a copy of the GNU General Public License
 along with evo.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import enum
 import re
+from typing import Union
+
+from rosbags.rosbag1.reader import Reader as Rosbag1Reader
+from rosbags.rosbag2.reader import Reader as Rosbag2Reader
 
 from evo import EvoException
 
@@ -27,6 +32,24 @@ ROS_NAME_REGEX = re.compile(r"[\/|a-z|A-Z][\/|_|0-9|a-z|A-Z]+")
 
 class TfIdException(EvoException):
     pass
+
+
+@enum.unique
+class HashSource(enum.Enum):
+    READER_INSTANCE = "reader_instance"
+    BAG_FILENAME = "filename"
+
+
+def hash_bag(reader: Union[Rosbag1Reader, Rosbag2Reader],
+             hash_source: HashSource) -> int:
+    """
+    Convenience function to hash a rosbag reader instance or its filename,
+    for using it as a key to tf_cache.instance()
+    """
+    if hash_source == HashSource.READER_INSTANCE:
+        return hash(reader)
+    elif hash_source == HashSource.BAG_FILENAME:
+        return hash(reader.path)
 
 
 def split_id(identifier: str) -> tuple:

--- a/evo/tools/tf_id.py
+++ b/evo/tools/tf_id.py
@@ -36,6 +36,10 @@ class TfIdException(EvoException):
 
 @enum.unique
 class HashSource(enum.Enum):
+    """
+    For choosing the source of the hash value when hashing a rosbag reader.
+    See hash_bag() for usage.
+    """
     READER_INSTANCE = "reader_instance"
     BAG_FILENAME = "filename"
 
@@ -46,10 +50,9 @@ def hash_bag(reader: Union[Rosbag1Reader, Rosbag2Reader],
     Convenience function to hash a rosbag reader instance or its filename,
     for using it as a key to tf_cache.instance()
     """
-    if hash_source == HashSource.READER_INSTANCE:
-        return hash(reader)
-    elif hash_source == HashSource.BAG_FILENAME:
+    if hash_source == HashSource.BAG_FILENAME:
         return hash(reader.path)
+    return hash(reader)
 
 
 def split_id(identifier: str) -> tuple:


### PR DESCRIPTION
Useful when multiple readers are instanced, e.g. when re-running a Jupyter notebook.