### PR TITLE
Feature/topiccsv

### DIFF
--- a/evo/main_traj.py
+++ b/evo/main_traj.py
@@ -111,6 +111,14 @@ def load_trajectories(args):
                     bag, args.ref, cache_tf_tree=True)
         finally:
             bag.close()
+    elif args.subcommand == "csv":
+        for traj_file in args.traj_files:
+            if traj_file == args.ref:
+                continue
+            trajectories[traj_file] = file_interface.read_csv_trajectory_file(
+                traj_file, args.topic_type)
+        if args.ref:
+            ref_traj = file_interface.read_csv_trajectory_file(args.ref, args.topic_type)
     return trajectories, ref_traj
 
 

--- a/evo/main_traj_parser.py
+++ b/evo/main_traj_parser.py
@@ -170,4 +170,22 @@ def parser() -> argparse.ArgumentParser:
     bag2_parser.add_argument("--all_topics",
                              help="use all compatible topics in the bag",
                              action="store_true")
+
+    csv_parser = sub_parsers.add_parser(
+        "csv",
+        description="%s for topic CSV files - %s" % (basic_desc, lic),
+        parents=[shared_parser])
+    csv_parser.add_argument(
+        "--topic_type", type=str, choices=[
+            "ros1odometry",
+            "ros1pose",
+            "ros1tf",
+            "ros2odometry",
+            "ros2pose",
+            "ros2tf",
+        ],
+        help="Explicitely specify the csv file format.")
+    csv_parser.add_argument("traj_files",
+                            help="one or multiple trajectory files", nargs='+')
+
     return main_parser

--- a/evo/tools/file_interface.py
+++ b/evo/tools/file_interface.py
@@ -403,8 +403,8 @@ def write_bag_trajectory(writer, traj: PoseTrajectory3D, topic_name: str,
 def _validate_csv_format(row: list[str], topic_info, log: bool) -> bool:
     if len(row) != int(topic_info["size"]):
         if log:
-            logger.warn("Cannot use message of type %s:", topic_info["name"])
-            logger.warn("Wrong record size %d, expected %d", len(row), topic_info["size"])
+            logger.warning("Cannot use message of type %s:", topic_info["name"])
+            logger.warning("Wrong record size %d, expected %d", len(row), topic_info["size"])
         return False
     
     for i in range(len(row)):
@@ -412,8 +412,8 @@ def _validate_csv_format(row: list[str], topic_info, log: bool) -> bool:
             try:
                 float(row[i])
             except:
-                logger.warn("Cannot use message of type %s:", topic_info["name"])
-                logger.warn("Expected float at %d, got '%s'", i, row[i])
+                logger.warning("Cannot use message of type %s:", topic_info["name"])
+                logger.warning("Expected float at %d, got '%s'", i, row[i])
                 return False
     return True
 

--- a/evo/tools/file_interface.py
+++ b/evo/tools/file_interface.py
@@ -408,13 +408,15 @@ def _validate_csv_format(row: list[str], topic_info, log: bool) -> bool:
         return False
     
     for i in range(len(row)):
-        if not i in topic_info["strpos"]:
-            try:
-                float(row[i])
-            except:
-                logger.warning("Cannot use message of type %s:", topic_info["name"])
-                logger.warning("Expected float at %d, got '%s'", i, row[i])
-                return False
+        try:
+            float(row[i])
+            actuallyfloat = True
+        except:
+            logger.warning("Cannot use message of type %s:", topic_info["name"])
+            logger.warning("Expected float at %d, got '%s'", i, row[i])
+            actuallyfloat = False
+        if actuallyfloat == i in topic_info["strpos"]:
+            return False
     return True
 
 def read_csv_trajectory_file(file_path: PathStrHandle, topic_type: str) -> PoseTrajectory3D:
@@ -434,13 +436,13 @@ def read_csv_trajectory_file(file_path: PathStrHandle, topic_type: str) -> PoseT
         }, {
             "name": "ros1odo",
             "size": 90, "strpos": [3, 4],
-            "secpos": 1, "nsecpos": 2,
+            "secpos": -1, "nsecpos": 2,
             "xpos": 5, "ypos": 6, "zpos": 7,
             "qx": 7, "qy": 8, "qz": 9, "qw": 10,
         }, {
             "name": "ros1pose",
-            "size": 11, "strpos": [4],
-            "secpos": 1, "nsecpos": 2,
+            "size": 11, "strpos": [3],
+            "secpos": -1, "nsecpos": 2,
             "xpos": 4, "ypos": 5, "zpos": 6,
             "qx": 7, "qy": 8, "qz": 9, "qw": 10,
         }, {
@@ -457,7 +459,7 @@ def read_csv_trajectory_file(file_path: PathStrHandle, topic_type: str) -> PoseT
             "qx": 6, "qy": 7, "qz": 8, "qw": 9,
         }, {
             "name": "ros2pose",
-            "size": 10, "strpos": [3],
+            "size": 10, "strpos": [2],
             "secpos": 0, "nsecpos": 1,
             "xpos": 3, "ypos": 4, "zpos": 5,
             "qx": 6, "qy": 7, "qz": 8, "qw": 9,

--- a/test/test_file_interface.py
+++ b/test/test_file_interface.py
@@ -187,7 +187,7 @@ class TestCsvFile(MockFileTestCase):
     @MockFileTestCase.run_and_clear
     def test_read_ros1tf(self):
         self.mock_file.write(u"%time,field.transforms0.header.seq,field.transforms0.header.stamp,field.transforms0.header.frame_id,field.transforms0.child_frame_id,field.transforms0.transform.translation.x,field.transforms0.transform.translation.y,field.transforms0.transform.translation.z,field.transforms0.transform.rotation.x,field.transforms0.transform.rotation.y,field.transforms0.transform.rotation.z,field.transforms0.transform.rotation.w\n")
-        self.mock_file.write(u"1739641583661579370,0,1739641583660682927,camera_init,aft_mapped,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238")
+        self.mock_file.write(u"1739641583661579370,5,1739641583660682927,camera_init,aft_mapped,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238")
         for topic_type in [None, "ros1tf"]:
             self.mock_file.seek(0)
             traj = file_interface.read_csv_trajectory_file(self.mock_file, topic_type)
@@ -198,13 +198,58 @@ class TestCsvFile(MockFileTestCase):
     @MockFileTestCase.run_and_clear
     def test_read_ros1odo(self):
         self.mock_file.write(u"%time,field.header.seq,field.header.stamp,field.header.frame_id,field.child_frame_id,field.pose.pose.position.x,field.pose.pose.position.y,field.pose.pose.position.z,field.pose.pose.orientation.x,field.pose.pose.orientation.y,field.pose.pose.orientation.z,field.pose.pose.orientation.w,field.pose.covariance0,field.pose.covariance1,field.pose.covariance2,field.pose.covariance3,field.pose.covariance4,field.pose.covariance5,field.pose.covariance6,field.pose.covariance7,field.pose.covariance8,field.pose.covariance9,field.pose.covariance10,field.pose.covariance11,field.pose.covariance12,field.pose.covariance13,field.pose.covariance14,field.pose.covariance15,field.pose.covariance16,field.pose.covariance17,field.pose.covariance18,field.pose.covariance19,field.pose.covariance20,field.pose.covariance21,field.pose.covariance22,field.pose.covariance23,field.pose.covariance24,field.pose.covariance25,field.pose.covariance26,field.pose.covariance27,field.pose.covariance28,field.pose.covariance29,field.pose.covariance30,field.pose.covariance31,field.pose.covariance32,field.pose.covariance33,field.pose.covariance34,field.pose.covariance35,field.twist.twist.linear.x,field.twist.twist.linear.y,field.twist.twist.linear.z,field.twist.twist.angular.x,field.twist.twist.angular.y,field.twist.twist.angular.z,field.twist.covariance0,field.twist.covariance1,field.twist.covariance2,field.twist.covariance3,field.twist.covariance4,field.twist.covariance5,field.twist.covariance6,field.twist.covariance7,field.twist.covariance8,field.twist.covariance9,field.twist.covariance10,field.twist.covariance11,field.twist.covariance12,field.twist.covariance13,field.twist.covariance14,field.twist.covariance15,field.twist.covariance16,field.twist.covariance17,field.twist.covariance18,field.twist.covariance19,field.twist.covariance20,field.twist.covariance21,field.twist.covariance22,field.twist.covariance23,field.twist.covariance24,field.twist.covariance25,field.twist.covariance26,field.twist.covariance27,field.twist.covariance28,field.twist.covariance29,field.twist.covariance30,field.twist.covariance31,field.twist.covariance32,field.twist.covariance33,field.twist.covariance34,field.twist.covariance35\n")
-        self.mock_file.write(u"1664948325587996960,0,1739641583660682927,/camera_init,/laser_odom,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0")
+        self.mock_file.write(u"1664948325587996960,5,1739641583660682927,/camera_init,/laser_odom,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0")
         for topic_type in [None, "ros1odo"]:
             self.mock_file.seek(0)
             traj = file_interface.read_csv_trajectory_file(self.mock_file, topic_type)
             self.assertEqual(traj.positions_xyz.all(), self.ref.positions_xyz.all())
             self.assertEqual(traj.orientations_quat_wxyz.all(), self.ref.orientations_quat_wxyz.all())
             self.assertEqual(traj.timestamps.all(), self.ref.timestamps.all())
+    
+    @MockFileTestCase.run_and_clear
+    def test_read_ros1pose(self):
+        self.mock_file.write(u"%time,field.header.seq,field.header.stamp,field.header.frame_id,field.pose.position.x,field.pose.position.y,field.pose.position.z,field.pose.orientation.x,field.pose.orientation.y,field.pose.orientation.z,field.pose.orientation.w\n")
+        self.mock_file.write(u"1664948329218966007,5,1739641583660682927,gt,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238")
+        for topic_type in [None, "ros1pose"]:
+            self.mock_file.seek(0)
+            traj = file_interface.read_csv_trajectory_file(self.mock_file, topic_type)
+            self.assertEqual(traj.positions_xyz.all(), self.ref.positions_xyz.all())
+            self.assertEqual(traj.orientations_quat_wxyz.all(), self.ref.orientations_quat_wxyz.all())
+            self.assertEqual(traj.timestamps.all(), self.ref.timestamps.all())
+    
+    @MockFileTestCase.run_and_clear
+    def test_read_ros2tf(self):
+        #header.stamp.sec,header.stamp.nanosec,header.frame_id,header.child_frame_id,field.pose.position.x,field.pose.position.y,field.pose.position.z,field.pose.orientation.x,field.pose.orientation.y,field.pose.orientation.z,field.pose.orientation.w
+        self.mock_file.write(u"1739641583,660682927,map,gt,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238")
+        for topic_type in [None, "ros2tf"]:
+            self.mock_file.seek(0)
+            traj = file_interface.read_csv_trajectory_file(self.mock_file, topic_type)
+            self.assertEqual(traj.positions_xyz.all(), self.ref.positions_xyz.all())
+            self.assertEqual(traj.orientations_quat_wxyz.all(), self.ref.orientations_quat_wxyz.all())
+            self.assertEqual(traj.timestamps.all(), self.ref.timestamps.all())
+    
+    @MockFileTestCase.run_and_clear
+    def test_read_ros2pose(self):
+        #stamp.sec,stamp.nanosec,field.header.frame_id,field.pose.position.x,field.pose.position.y,field.pose.position.z,field.pose.orientation.x,field.pose.orientation.y,field.pose.orientation.z,field.pose.orientation.w
+        self.mock_file.write(u"1739641583,660682927,gt,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238")
+        for topic_type in [None, "ros2pose"]:
+            self.mock_file.seek(0)
+            traj = file_interface.read_csv_trajectory_file(self.mock_file, topic_type)
+            self.assertEqual(traj.positions_xyz.all(), self.ref.positions_xyz.all())
+            self.assertEqual(traj.orientations_quat_wxyz.all(), self.ref.orientations_quat_wxyz.all())
+            self.assertEqual(traj.timestamps.all(), self.ref.timestamps.all())
+    
+    @MockFileTestCase.run_and_clear
+    def test_read_ros2odo(self):
+        #header.stamp.sec,header.stamp.nanosec,header.frame_id,child_frame_id,pose.pose.position.x,pose.pose.position.y,pose.pose.position.z,pose.pose.orientation.x,pose.pose.orientation.y,pose.pose.orientation.z,pose.pose.orientation.w,pose.covariance0,pose.covariance1,pose.covariance2,pose.covariance3,pose.covariance4,pose.covariance5,pose.covariance6,pose.covariance7,pose.covariance8,pose.covariance9,pose.covariance10,pose.covariance11,pose.covariance12,pose.covariance13,pose.covariance14,pose.covariance15,pose.covariance16,pose.covariance17,pose.covariance18,pose.covariance19,pose.covariance20,pose.covariance21,pose.covariance22,pose.covariance23,pose.covariance24,pose.covariance25,pose.covariance26,pose.covariance27,pose.covariance28,pose.covariance29,pose.covariance30,pose.covariance31,pose.covariance32,pose.covariance33,pose.covariance34,pose.covariance35,twist.twist.linear.x,twist.twist.linear.y,twist.twist.linear.z,twist.twist.angular.x,twist.twist.angular.y,twist.twist.angular.z,twist.covariance0,twist.covariance1,twist.covariance2,twist.covariance3,twist.covariance4,twist.covariance5,twist.covariance6,twist.covariance7,twist.covariance8,twist.covariance9,twist.covariance10,twist.covariance11,twist.covariance12,twist.covariance13,twist.covariance14,twist.covariance15,twist.covariance16,twist.covariance17,twist.covariance18,twist.covariance19,twist.covariance20,twist.covariance21,twist.covariance22,twist.covariance23,twist.covariance24,twist.covariance25,twist.covariance26,twist.covariance27,twist.covariance28,twist.covariance29,twist.covariance30,twist.covariance31,twist.covariance32,twist.covariance33,twist.covariance34,twist.covariance35\n")
+        self.mock_file.write(u"1739641583,660682927,/camera_init,/laser_odom,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0")
+        for topic_type in [None, "ros2odo"]:
+            self.mock_file.seek(0)
+            traj = file_interface.read_csv_trajectory_file(self.mock_file, topic_type)
+            self.assertEqual(traj.positions_xyz.all(), self.ref.positions_xyz.all())
+            self.assertEqual(traj.orientations_quat_wxyz.all(), self.ref.orientations_quat_wxyz.all())
+            self.assertEqual(traj.timestamps.all(), self.ref.timestamps.all())
+
 
 class TestResultFile(MockFileTestCase):
     def __init__(self, *args, **kwargs):

--- a/test/test_file_interface.py
+++ b/test/test_file_interface.py
@@ -174,6 +174,25 @@ class TestBagFile(MockFileTestCase):
             self.assertTrue(traj_out == traj_in)
             self.assertEqual(traj_in.meta["frame_id"], "map")
 
+class TestCsvFile(MockFileTestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestCsvFile, self).__init__(io.StringIO(), *args, **kwargs)
+
+        # The reference trajectory:
+        stamps = [1739641583.660682927]
+        xyz = [[-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05]]
+        quat = [[1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238]]
+        self.ref = PoseTrajectory3D(xyz, quat, stamps)
+    
+    @MockFileTestCase.run_and_clear
+    def test_read_ros1tf(self):
+        self.mock_file.write(u"%time,field.transforms0.header.seq,field.transforms0.header.stamp,field.transforms0.header.frame_id,field.transforms0.child_frame_id,field.transforms0.transform.translation.x,field.transforms0.transform.translation.y,field.transforms0.transform.translation.z,field.transforms0.transform.rotation.x,field.transforms0.transform.rotation.y,field.transforms0.transform.rotation.z,field.transforms0.transform.rotation.w\n")
+        self.mock_file.write(u"1739641583661579370,0,1739641583660682927,camera_init,aft_mapped,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238")
+        self.mock_file.seek(0)
+        traj = file_interface.read_csv_trajectory_file(self.mock_file, None)
+        self.assertEqual(traj.positions_xyz.all(), self.ref.positions_xyz.all())
+        self.assertEqual(traj.orientations_quat_wxyz.all(), self.ref.orientations_quat_wxyz.all())
+        self.assertEqual(traj.timestamps.all(), self.ref.timestamps.all())
 
 class TestResultFile(MockFileTestCase):
     def __init__(self, *args, **kwargs):

--- a/test/test_file_interface.py
+++ b/test/test_file_interface.py
@@ -188,11 +188,23 @@ class TestCsvFile(MockFileTestCase):
     def test_read_ros1tf(self):
         self.mock_file.write(u"%time,field.transforms0.header.seq,field.transforms0.header.stamp,field.transforms0.header.frame_id,field.transforms0.child_frame_id,field.transforms0.transform.translation.x,field.transforms0.transform.translation.y,field.transforms0.transform.translation.z,field.transforms0.transform.rotation.x,field.transforms0.transform.rotation.y,field.transforms0.transform.rotation.z,field.transforms0.transform.rotation.w\n")
         self.mock_file.write(u"1739641583661579370,0,1739641583660682927,camera_init,aft_mapped,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238")
-        self.mock_file.seek(0)
-        traj = file_interface.read_csv_trajectory_file(self.mock_file, None)
-        self.assertEqual(traj.positions_xyz.all(), self.ref.positions_xyz.all())
-        self.assertEqual(traj.orientations_quat_wxyz.all(), self.ref.orientations_quat_wxyz.all())
-        self.assertEqual(traj.timestamps.all(), self.ref.timestamps.all())
+        for topic_type in [None, "ros1tf"]:
+            self.mock_file.seek(0)
+            traj = file_interface.read_csv_trajectory_file(self.mock_file, topic_type)
+            self.assertEqual(traj.positions_xyz.all(), self.ref.positions_xyz.all())
+            self.assertEqual(traj.orientations_quat_wxyz.all(), self.ref.orientations_quat_wxyz.all())
+            self.assertEqual(traj.timestamps.all(), self.ref.timestamps.all())
+    
+    @MockFileTestCase.run_and_clear
+    def test_read_ros1odo(self):
+        self.mock_file.write(u"%time,field.header.seq,field.header.stamp,field.header.frame_id,field.child_frame_id,field.pose.pose.position.x,field.pose.pose.position.y,field.pose.pose.position.z,field.pose.pose.orientation.x,field.pose.pose.orientation.y,field.pose.pose.orientation.z,field.pose.pose.orientation.w,field.pose.covariance0,field.pose.covariance1,field.pose.covariance2,field.pose.covariance3,field.pose.covariance4,field.pose.covariance5,field.pose.covariance6,field.pose.covariance7,field.pose.covariance8,field.pose.covariance9,field.pose.covariance10,field.pose.covariance11,field.pose.covariance12,field.pose.covariance13,field.pose.covariance14,field.pose.covariance15,field.pose.covariance16,field.pose.covariance17,field.pose.covariance18,field.pose.covariance19,field.pose.covariance20,field.pose.covariance21,field.pose.covariance22,field.pose.covariance23,field.pose.covariance24,field.pose.covariance25,field.pose.covariance26,field.pose.covariance27,field.pose.covariance28,field.pose.covariance29,field.pose.covariance30,field.pose.covariance31,field.pose.covariance32,field.pose.covariance33,field.pose.covariance34,field.pose.covariance35,field.twist.twist.linear.x,field.twist.twist.linear.y,field.twist.twist.linear.z,field.twist.twist.angular.x,field.twist.twist.angular.y,field.twist.twist.angular.z,field.twist.covariance0,field.twist.covariance1,field.twist.covariance2,field.twist.covariance3,field.twist.covariance4,field.twist.covariance5,field.twist.covariance6,field.twist.covariance7,field.twist.covariance8,field.twist.covariance9,field.twist.covariance10,field.twist.covariance11,field.twist.covariance12,field.twist.covariance13,field.twist.covariance14,field.twist.covariance15,field.twist.covariance16,field.twist.covariance17,field.twist.covariance18,field.twist.covariance19,field.twist.covariance20,field.twist.covariance21,field.twist.covariance22,field.twist.covariance23,field.twist.covariance24,field.twist.covariance25,field.twist.covariance26,field.twist.covariance27,field.twist.covariance28,field.twist.covariance29,field.twist.covariance30,field.twist.covariance31,field.twist.covariance32,field.twist.covariance33,field.twist.covariance34,field.twist.covariance35\n")
+        self.mock_file.write(u"1664948325587996960,0,1739641583660682927,/camera_init,/laser_odom,-5.662295808104799e-05,0.00016827168702906548,3.5524415470101045e-05,1.9329304695625015e-06,1.3492393190741297e-05,-0.0005278167789287769,0.9999998606118238,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0")
+        for topic_type in [None, "ros1odo"]:
+            self.mock_file.seek(0)
+            traj = file_interface.read_csv_trajectory_file(self.mock_file, topic_type)
+            self.assertEqual(traj.positions_xyz.all(), self.ref.positions_xyz.all())
+            self.assertEqual(traj.orientations_quat_wxyz.all(), self.ref.orientations_quat_wxyz.all())
+            self.assertEqual(traj.timestamps.all(), self.ref.timestamps.all())
 
 class TestResultFile(MockFileTestCase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Hello,

both ROS1 and ROS2 provide command line functionality to directly output topic messages as csv files:
```bash
 ~ rostopic echo --help
# [...]
  -p                    echo in a plotting friendly format
# [...]
 ~ ros2 topic echo --help
# [...]
  --csv                 Output all recursive fields separated by commas (e.g. for plotting)
# [...]
```

This output format offers some advantages, namely:
 - independent of ROS installation -> easy sharing between computers + containers
 - text format -> readable without any command line tools
 - platform independent

All csv files are somewhat comparable in their structure, however there are some minor differences:
 - ROS1 csv files have a comment header describing all fields, which ROS2 doesn't have
 - ROS1 uses a single `stamp` field which contains the time in nanoseconds, while ROS2 has a `seconds` and `nanoseconds` field

In this PR, I suggest adding functionality for reading these `csv` files with `evo`.
It is possible to explicitely specify which type of csv file is provided using the command line switch `--topic-type`.
If no topic type is specified, the topic type is guessed by checking each file against a hardcoded list of topic type specifications (`TOPIC_INFOS`).
I validate both the csv record length as well as data types.
With these topic types currently supported:
 - [`geometry_msgs/PoseStamped` (ROS1)](http://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/PoseStamped.html) and [`geometry_msgs/msg/PoseStamped` (ROS2)](https://docs.ros2.org/foxy/api/geometry_msgs/msg/PoseStamped.html)
 - [`nav_msgs/Odometry` (ROS1)](https://docs.ros.org/en/noetic/api/nav_msgs/html/msg/Odometry.html) and [`nav_msgs/msg/Odometry` (ROS2)](https://docs.ros2.org/foxy/api/nav_msgs/msg/Odometry.html)
 - [`tf2_msgs/TFMessage` (ROS1)](https://docs.ros.org/en/noetic/api/tf2_msgs/html/msg/TFMessage.html) and [`tf2_msgs/msg/TFMessage` (ROS2)](https://docs.ros2.org/foxy/api/tf2_msgs/msg/TFMessage.html)**

There are no conflicting message specifications.

** The `TFMessage` contains an array of `TransformStamped` elements, which are automatically flattened by `rostopic echo` / `ros2 topic echo`.

The csv file is evaluated in `tools/file_interface.py` as a matlab matrix. I've also added some basic unit tests for all formats.

I've so far found an issue, that is `ros2 topic echo` will emit a message like this *in stdout*:
```
A message was lost!!!
  total count change:1
  total count: 1---
```
I don't think there is much to do about this if we don't want to rework how csv file reading works.
