### PR TITLE
Add --rerun to log evo_ape/rpe to rerun

### DIFF
--- a/contrib/rerun_example/rerun_example.py
+++ b/contrib/rerun_example/rerun_example.py
@@ -21,8 +21,7 @@ from matplotlib.colors import to_rgba
 from evo.core.trajectory import PoseTrajectory3D
 from evo.core import metrics, sync
 from evo.tools import file_interface
-
-import rerun_bridge as revo
+from evo.tools import rerun_bridge as revo
 
 # The script assumes that it sits in the contrib/rerun_example directory of the evo repo.
 TEST_DATA_DIR = Path(__file__).parent.parent.parent / "test/data"

--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -261,18 +261,29 @@ def log_result_to_rerun(entity_parent: str, result: Result,
         end=rrb.TimeRangeBoundary.cursor_relative(seconds=0.0),
     )
 
-    # Show a 3D view and a plot.
+    # Configure the blueprint (3D view, plot, etc.).
     rr.send_blueprint(
         rrb.Blueprint(
-            rrb.Grid(
-                contents=[
-                    rrb.Spatial3DView(time_ranges=time_range),
-                    rrb.TimeSeriesView(time_ranges=time_range),
-                ],
-                column_shares=None,
-                row_shares=[2.5, 1.],
-                grid_columns=1,
-            ),
+            rrb.Tabs(contents=[
+                rrb.Grid(
+                    name="Visualization",
+                    contents=[
+                        rrb.Spatial3DView(name="Trajectories",
+                                          time_ranges=time_range),
+                        rrb.TimeSeriesView(name="Error",
+                                           time_ranges=time_range),
+                    ],
+                    column_shares=None,
+                    row_shares=[2.5, 1.],
+                    grid_columns=1,
+                ),
+                rrb.DataframeView(
+                    name="Raw Data", origin=f"/{entity_parent}", contents=[
+                        "$origin/reference/transforms",
+                        "$origin/estimate/transforms",
+                        "$origin/error/scalars",
+                    ]),
+            ]),
             # Expand/collapse the selection and detailed time panels by default?
             rrb.SelectionPanel(expanded=False),
             rrb.TimePanel(expanded=False),

--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -295,41 +295,12 @@ def log_result_to_rerun(app_id: str, result: Result,
         error_array = np.insert(error_array, 0, 0.0)
     error_colors = mapped_colors(SETTINGS.plot_trajectory_cmap, error_array)
 
-    # Log the estimate's trajectory with colors mapped to the error.
-    revo.log_transforms(entity_path=f"{app_id}/estimate/transforms",
-                        traj=traj_est,
-                        axis_length=SETTINGS.plot_axis_marker_scale)
-    revo.log_points(
-        entity_path=f"{app_id}/estimate/points",
-        traj=traj_est,
-        radii=revo.ui_points_radii(SETTINGS.plot_linewidth * 1.25),
-        color=revo.Color(sequential=error_colors),
-    )
-    revo.log_line_strips(
-        entity_path=f"{app_id}/estimate/lines",
-        traj=traj_est,
-        radii=revo.ui_points_radii(SETTINGS.plot_linewidth),
-        color=revo.Color(sequential=error_colors[1:]),
-    )
-
-    # Log the reference trajectory.
-    revo.log_transforms(entity_path=f"{app_id}/reference/transforms",
-                        traj=traj_ref,
-                        axis_length=SETTINGS.plot_axis_marker_scale)
-    revo.log_points(
-        entity_path=f"{app_id}/reference/points",
-        traj=traj_ref,
-        radii=revo.ui_points_radii(SETTINGS.plot_linewidth * 1.25),
+    revo.log_trajectory(entity_path=f"{app_id}/estimate", traj=traj_est,
+                        color=revo.Color(sequential=error_colors))
+    revo.log_trajectory(
+        entity_path=f"{app_id}/reference", traj=traj_ref,
         color=revo.Color(static=to_rgba(SETTINGS.plot_reference_color,
-                                        alpha=SETTINGS.plot_reference_alpha)),
-    )
-    revo.log_line_strips(
-        entity_path=f"{app_id}/reference/lines",
-        traj=traj_ref,
-        radii=revo.ui_points_radii(SETTINGS.plot_linewidth),
-        color=revo.Color(static=to_rgba(SETTINGS.plot_reference_color,
-                                        alpha=SETTINGS.plot_reference_alpha)),
-    )
+                                        alpha=SETTINGS.plot_reference_alpha)))
 
     # Log the correspondence edges if enabled.
     if SETTINGS.plot_pose_correspondences:

--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -302,17 +302,18 @@ def log_result_to_rerun(app_id: str, result: Result,
         color=revo.Color(static=to_rgba(SETTINGS.plot_reference_color,
                                         alpha=SETTINGS.plot_reference_alpha)))
 
-    # Log the correspondence edges if enabled.
-    if SETTINGS.plot_pose_correspondences:
-        revo.log_correspondence_strips(
-            entity_path=f"{app_id}/error/correspondences",
-            traj_1=traj_est,
-            traj_2=traj_ref,
-            color=revo.Color(
-                static=to_rgba(SETTINGS.plot_reference_color,
-                               alpha=SETTINGS.plot_reference_alpha)),
-            radii=revo.ui_points_radii(SETTINGS.plot_linewidth / 2.),
-        )
+    # Log the correspondence edges.
+    # In contrast to the matplotlib plot, we always do this here independent of
+    # SETTINGS.plot_pose_correspondences.
+    # It can be toggled in the rerun viewer and the logging is lightweight.
+    revo.log_correspondence_strips(
+        entity_path=f"{app_id}/error/correspondences",
+        traj_1=traj_est,
+        traj_2=traj_ref,
+        color=revo.Color(static=to_rgba(SETTINGS.plot_reference_color,
+                                        alpha=SETTINGS.plot_reference_alpha)),
+        radii=revo.ui_points_radii(SETTINGS.plot_linewidth / 2.),
+    )
 
     # Log the error scalars.
     revo.log_scalars(

--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -289,13 +289,6 @@ def log_result_to_rerun(app_id: str, result: Result,
             rrb.TimePanel(expanded=False),
         ))
 
-    revo.log_transforms(entity_path=f"{app_id}/reference/transforms",
-                        traj=traj_ref,
-                        axis_length=SETTINGS.plot_axis_marker_scale)
-    revo.log_transforms(entity_path=f"{app_id}/estimate/transforms",
-                        traj=traj_est,
-                        axis_length=SETTINGS.plot_axis_marker_scale)
-
     error_array = result.np_arrays["error_array"]
     if app_id == "evo_rpe":
         # Pad RPE with 0. at the start to match the length of APE error arrays.
@@ -303,6 +296,9 @@ def log_result_to_rerun(app_id: str, result: Result,
     error_colors = mapped_colors(SETTINGS.plot_trajectory_cmap, error_array)
 
     # Log the estimate's trajectory with colors mapped to the error.
+    revo.log_transforms(entity_path=f"{app_id}/estimate/transforms",
+                        traj=traj_est,
+                        axis_length=SETTINGS.plot_axis_marker_scale)
     revo.log_points(
         entity_path=f"{app_id}/estimate/points",
         traj=traj_est,
@@ -317,6 +313,9 @@ def log_result_to_rerun(app_id: str, result: Result,
     )
 
     # Log the reference trajectory.
+    revo.log_transforms(entity_path=f"{app_id}/reference/transforms",
+                        traj=traj_ref,
+                        axis_length=SETTINGS.plot_axis_marker_scale)
     revo.log_points(
         entity_path=f"{app_id}/reference/points",
         traj=traj_ref,

--- a/evo/main_ape.py
+++ b/evo/main_ape.py
@@ -159,6 +159,9 @@ def run(args: argparse.Namespace) -> None:
                  est_name=est_name, change_unit=change_unit,
                  project_to_plane=plane)
 
+    if args.rerun:
+        common.log_result_to_rerun("evo_ape", result, traj_ref, traj_est)
+
     if args.plot or args.save_plot or args.serialize_plot:
         common.plot_result(args, result, traj_ref,
                            result.trajectories[est_name],

--- a/evo/main_ape_parser.py
+++ b/evo/main_ape_parser.py
@@ -94,6 +94,8 @@ def parser() -> argparse.ArgumentParser:
                              help="path to save plot")
     output_opts.add_argument("--serialize_plot", default=None,
                              help="path to serialize plot (experimental)")
+    output_opts.add_argument("--rerun", action="store_true",
+                             help="Log visualization data to rerun.")
     output_opts.add_argument("--save_results",
                              help=".zip file path to store results")
     output_opts.add_argument("--logfile", help="Local logfile path.",

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -182,6 +182,9 @@ def run(args: argparse.Namespace) -> None:
                  ref_name=ref_name, est_name=est_name, change_unit=change_unit,
                  project_to_plane=plane)
 
+    if args.rerun:
+        common.log_result_to_rerun("evo_rpe", result, traj_ref, traj_est)
+
     if args.plot or args.save_plot or args.serialize_plot:
         common.plot_result(args, result, traj_ref,
                            result.trajectories[est_name],

--- a/evo/main_rpe_parser.py
+++ b/evo/main_rpe_parser.py
@@ -109,6 +109,8 @@ def parser() -> argparse.ArgumentParser:
                              help="path to save plot")
     output_opts.add_argument("--serialize_plot", default=None,
                              help="path to serialize plot (experimental)")
+    output_opts.add_argument("--rerun", action="store_true",
+                             help="Log visualization data to rerun.")
     output_opts.add_argument("--save_results",
                              help=".zip file path to store results")
     output_opts.add_argument("--logfile", help="Local logfile path.",

--- a/evo/tools/rerun_bridge.py
+++ b/evo/tools/rerun_bridge.py
@@ -200,6 +200,9 @@ def log_trajectory(entity_path: str, traj: PoseTrajectory3D,
     """
     Convenience function to log transforms, points, and lines to rerun.
     """
+    # Note: in contrast to plot.py, we always log transform axes here.
+    # If the scale is 0., you can still make it visible in the rerun
+    # viewer by changing the length in the entity settings after logging.
     log_transforms(entity_path=f"{entity_path}/transforms", traj=traj,
                    axis_length=SETTINGS.plot_axis_marker_scale)
     log_points(

--- a/evo/tools/rerun_bridge.py
+++ b/evo/tools/rerun_bridge.py
@@ -44,6 +44,13 @@ def _to_time_column(timestamps: np.ndarray) -> rr.TimeColumn:
     return rr.TimeColumn(TIMELINE, timestamp=list(timestamps))
 
 
+def ui_points_radii(value: Float32ArrayLike) -> Float32ArrayLike:
+    """
+    rerun interprets negative radii as points in screen space.
+    """
+    return -np.abs(value)
+
+
 def mapped_colors(cmap_name: str, values: np.ndarray) -> Sequence[int]:
     """
     Creates a color sequence from scalar values using a matplotlib colormap.

--- a/evo/tools/rerun_bridge.py
+++ b/evo/tools/rerun_bridge.py
@@ -13,6 +13,7 @@ import matplotlib.cm
 from matplotlib.colors import Normalize, rgb2hex
 
 from evo.core.trajectory import PoseTrajectory3D
+from evo.tools.settings import SETTINGS
 
 TIMELINE = "time"
 
@@ -191,4 +192,26 @@ def log_correspondence_strips(
         entity_path,
         rr.LineStrips3D.from_fields(colors=color.static, radii=radii),
         static=True,
+    )
+
+
+def log_trajectory(entity_path: str, traj: PoseTrajectory3D,
+                   color: Color) -> None:
+    """
+    Convenience function to log transforms, points, and lines to rerun.
+    """
+    log_transforms(entity_path=f"{entity_path}/transforms", traj=traj,
+                   axis_length=SETTINGS.plot_axis_marker_scale)
+    log_points(
+        entity_path=f"{entity_path}/points",
+        traj=traj,
+        radii=ui_points_radii(SETTINGS.plot_linewidth * 1.25),
+        color=color,
+    )
+    log_line_strips(
+        entity_path=f"{entity_path}/lines",
+        traj=traj,
+        radii=ui_points_radii(SETTINGS.plot_linewidth),
+        color=color if color.static is not None else Color(
+            sequential=color.sequential[1:]),
     )

--- a/evo/tools/settings_template.py
+++ b/evo/tools/settings_template.py
@@ -214,6 +214,11 @@ DEFAULT_SETTINGS_DICT_DOC = {
         "Style used for the syntax highlighting in evo_config.\n"
         "See here for available styles: https://pygments.org/styles/"
     ),
+    "rerun_spawn": (
+        True,
+        "Spawn a viewer window when logging data to rerun.\n"
+        "If set to False, the viewer must be started manually."
+    ),
     "ros_map_alpha_value": (
         1.0,
         "Alpha value for blending ROS map image slices."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "pyyaml",
     "pillow",
     "rosbags>=0.10.9",
+    "packaging",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
With `rerun-sdk` installed via pip, just add `--rerun` to the command
to log the trajectory and result data to rerun for a fast 3D viewer with
replay capability.

Contributes to: #7

<img width="3248" height="2002" alt="grafik" src="https://github.com/user-attachments/assets/3a2dd0bc-7da1-4851-8da1-d6384a3c23d0" />
