### PR TITLE
Catch conflicting alignment options also in main functions

### DIFF
--- a/evo/main_ape.py
+++ b/evo/main_ape.py
@@ -51,6 +51,8 @@ def ape(
     change_unit: metrics.Unit | None = None,
     project_to_plane: Plane | None = None,
 ) -> Result:
+    if align and align_origin:
+        raise ValueError("align and align_origin can't be used simultaneously")
 
     # Align the trajectories.
     only_scale = correct_scale and not align

--- a/evo/main_rpe.py
+++ b/evo/main_rpe.py
@@ -57,6 +57,8 @@ def rpe(
     change_unit: metrics.Unit | None = None,
     project_to_plane: Plane | None = None,
 ) -> Result:
+    if align and align_origin:
+        raise ValueError("align and align_origin can't be used simultaneously")
 
     # Align the trajectories.
     only_scale = correct_scale and not align


### PR DESCRIPTION
This was already caught by a mutually exclusive arg group for CLI users, see https://github.com/MichaelGrupp/evo/blob/718a4bbbbd43b7a93d4d4bdf200460a41eff917b/evo/main_ape_parser.py#L71 but it doesn't hurt to check this also in the code if someone uses that directly.

Relates to #768