### PR TITLE
Use first TF topic timestamp as start_time in `TfCache`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,3 +12,5 @@ max-branches=13
 # f-strings are nicer to maintain.
 disable=logging-fstring-interpolation
 
+# We do lazy imports in multiple places.
+disable=import-outside-toplevel

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,11 +6,10 @@ max-branches=13
 
 [MESSAGES CONTROL]
 
-# Allow f-strings as valid log formatting in addition to % formatting
-# (still warns about .format(), which we don't want anymore).
-# The performance impact of % is neglectible for this application and
-# f-strings are nicer to maintain.
-disable=logging-fstring-interpolation
-
-# We do lazy imports in multiple places.
-disable=import-outside-toplevel
+# logging-fstring-interpolation: allow f-strings as valid log formatting in
+#   addition to % formatting (still warns about .format(), which we don't want
+#   anymore). The performance impact of % is neglectible for this application
+#   and f-strings are nicer to maintain.
+# import-outside-toplevel: we do lazy imports in multiple places.
+disable=logging-fstring-interpolation,
+        import-outside-toplevel

--- a/evo/tools/log.py
+++ b/evo/tools/log.py
@@ -78,7 +78,6 @@ def configure_logging(
 ) -> None:
 
     logger = logging.getLogger("evo")
-    logger.setLevel(logging.DEBUG)
     logger.propagate = False
 
     if len(logger.handlers) > 0:
@@ -112,6 +111,10 @@ def configure_logging(
     console_handler.setLevel(console_level)
     console_handler.setFormatter(ConsoleFormatter(console_fmt))
     logger.addHandler(console_handler)
+
+    # Track the lowest level any handler will accept so isEnabledFor() reflects
+    # whether a record will actually reach a handler, not just the logger.
+    logger.setLevel(min(h.level for h in logger.handlers))
 
     # log header for debug mode
     if debug:

--- a/evo/tools/settings_template.py
+++ b/evo/tools/settings_template.py
@@ -277,6 +277,11 @@ DEFAULT_SETTINGS_DICT_DOC = {
         True,
         "Transpose tables for export."
     ),
+    "tf_cache_debug": (
+        False,
+        "Log debug information about the TF buffer contents.\n"
+        "Potentially very spammy and only shown when debug/verbose logging is enabled."
+    ),
     "tf_cache_lookup_frequency": (
         10,
         "Frequency for looking up transformations when loading trajectories \n"

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -24,11 +24,9 @@ import logging
 import math
 import warnings
 from collections import defaultdict
-from pathlib import Path
 from typing import (
     DefaultDict,
     Protocol,
-    cast,
     runtime_checkable,
 )
 
@@ -132,14 +130,8 @@ def to_sec(
 
 @dataclasses.dataclass
 class TimeSpec:
-    seconds: int
-    nanoseconds: int
-
-    def as_seconds(self) -> float:
-        return float(self.seconds) + self.nanoseconds * 1e-9
-
-    def as_nanoseconds(self) -> int:
-        return int(self.seconds * 1e9) + self.nanoseconds
+    sec: int
+    nanosec: int
 
 
 @dataclasses.dataclass
@@ -352,24 +344,19 @@ class TfCache(object):
             _start_time: TimeSpec = self.cache[CacheKey(reader, topic)]
 
             if hasattr(latest_time, "nsecs"):
-                from rospy import (
-                    Time,
-                    Duration,
-                )  # pylint: disable=import-outside-toplevel
+                from rospy import Time, Duration
 
-                start_time = Time.from_sec(_start_time.as_seconds())
+                start_time = Time(_start_time.sec, _start_time.nanosec)
                 step = Duration.from_sec(
                     1.0 / SETTINGS.tf_cache_lookup_frequency
                 )
             else:
-                from rclpy.time import (
-                    Time,
-                )  # pylint: disable=import-outside-toplevel
-                from rclpy.duration import (
-                    Duration,
-                )  # pylint: disable=import-outside-toplevel
+                from rclpy.time import Time
+                from rclpy.duration import Duration
 
-                start_time = Time(nanoseconds=_start_time.as_nanoseconds())
+                start_time = Time(
+                    seconds=_start_time.sec, nanoseconds=_start_time.nanosec
+                )
                 step = Duration(
                     seconds=1.0 / SETTINGS.tf_cache_lookup_frequency
                 )

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_TF_MSG = "tf2_msgs/msg/TFMessage"
 DEFAULT_MAX_TIME = SETTINGS.tf_cache_max_time
-DEFAULT_DEBUG = SETTINGS.tf_cache_debug and logger.isEnabledFor(logging.DEBUG)
+DEFAULT_DEBUG = SETTINGS.tf_cache_debug
 
 
 class TfCacheException(EvoException):
@@ -295,7 +295,8 @@ class TfCache(object):
                         self.buffer.set_transform_static(native_msg, __name__)
                     else:
                         self.buffer.set_transform(native_msg, __name__)
-            if self.debug:
+
+            if self.debug and logger.isEnabledFor(logging.DEBUG):
                 logger.debug("TF buffer:\n" + self.buffer.all_frames_as_yaml())
 
     def lookup_trajectory(

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -297,7 +297,7 @@ class TfCache(object):
                         self.buffer.set_transform(native_msg, __name__)
 
             if self.debug:
-                logger.debug("TF buffer:\n" + self.buffer.all_frames_as_yaml())
+                logger.debug("TF buffer: %s", self.buffer.all_frames_as_yaml())
 
     def lookup_trajectory(
         self,

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -130,23 +130,48 @@ def to_sec(
     return timestamp.sec + timestamp.nanosec * 1e-9
 
 
+@dataclasses.dataclass
+class TimeSpec:
+    seconds: int
+    nanoseconds: int
+
+    def as_seconds(self) -> float:
+        return float(self.seconds) + self.nanoseconds * 1e-9
+
+    def as_nanoseconds(self) -> int:
+        return int(self.seconds * 1e9) + self.nanoseconds
+
+
+@dataclasses.dataclass
+class CacheKey:
+    reader: Rosbag1Reader | Rosbag2Reader
+    topic: str
+
+    def __hash__(self):
+        return hash(f"{self.reader.path}+{self.topic}")
+
+
+@dataclasses.dataclass
+class CacheEntry:
+    # Earliest timestamp of a TF message on this topic.
+    start_time: TimeSpec
+
+
 class TfCache(object):
     """
     For caching TF messages and looking up trajectories of specific transforms.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.buffer = tf2_py.BufferCore(
             TfDuration.from_sec(SETTINGS.tf_cache_max_time)
         )
-        self.topics = []
-        self.bags = []
+        self.cache: dict[CacheKey, CacheEntry] = {}
 
     def clear(self) -> None:
         logger.debug("Clearing TF cache.")
         self.buffer.clear()
-        self.topics = []
-        self.bags = []
+        self.cache = {}
 
     # tf2_msgs/TFMessage is not included in default rosbags typestore,
     # update the ROS1 typestore with the interface definition from the bag.
@@ -193,17 +218,15 @@ class TfCache(object):
 
         # Add TF data to buffer if this bag/topic pair is not already cached.
         for tf_topic in tf_topics:
-            if (
-                tf_topic in self.topics
-                and cast(Path, reader.path).name in self.bags
-            ):
+            cache_key = CacheKey(reader, topic)
+            if cache_key in self.cache:
                 logger.debug(
-                    f"Using cache for topic {tf_topic} from {cast(Path, reader.path).name}"
+                    f"Using cache for topic {tf_topic} from {reader.path}"
                 )
                 continue
-            logger.debug(
-                f"Caching TF topic {tf_topic} from {cast(Path, reader.path).name} ..."
-            )
+            logger.debug(f"Caching TF topic {tf_topic} from {reader.path} ...")
+            start_time = None
+
             connections = [
                 c for c in reader.connections if c.topic == tf_topic
             ]
@@ -223,7 +246,17 @@ class TfCache(object):
                     msg = typestore.deserialize_cdr(
                         rawdata, connection.msgtype
                     )
+
                 for tf in msg.transforms:  # type: ignore
+                    # Store the time of the first TF message.
+                    # This is more robust than reader.start_time,
+                    # e.g. when sim time was used (see also: #771)
+                    if start_time is None:
+                        start_time = TimeSpec(
+                            tf.header.stamp.sec, tf.header.stamp.nanosec
+                        )
+                        self.cache[cache_key] = CacheEntry(start_time)
+
                     # Convert from rosbags.typesys.types to native ROS.
                     # Related: https://gitlab.com/ternaris/rosbags/-/issues/13
                     native_msg = TransformStamped()
@@ -254,8 +287,6 @@ class TfCache(object):
                         self.buffer.set_transform_static(native_msg, __name__)
                     else:
                         self.buffer.set_transform(native_msg, __name__)
-            self.topics.append(tf_topic)
-        self.bags.append(cast(Path, reader.path).name)
 
     def lookup_trajectory(
         self,
@@ -323,14 +354,17 @@ class TfCache(object):
             except (tf2_py.LookupException, tf2_py.TransformException) as e:
                 raise TfCacheException("Could not load trajectory: " + str(e))
 
+            _start_time: TimeSpec = self.cache[
+                CacheKey(reader, topic)
+            ].start_time
+
             if hasattr(latest_time, "nsecs"):
                 from rospy import (
                     Time,
                     Duration,
                 )  # pylint: disable=import-outside-toplevel
 
-                # rosbags Reader start_time is in nanoseconds.
-                start_time = Time.from_sec(reader.start_time * 1e-9)
+                start_time = Time.from_sec(_start_time.as_seconds())
                 step = Duration.from_sec(
                     1.0 / SETTINGS.tf_cache_lookup_frequency
                 )
@@ -342,8 +376,7 @@ class TfCache(object):
                     Duration,
                 )  # pylint: disable=import-outside-toplevel
 
-                # rosbags Reader start_time is in nanoseconds.
-                start_time = Time(nanoseconds=reader.start_time)
+                start_time = Time(nanoseconds=_start_time.as_nanoseconds())
                 step = Duration(
                     seconds=1.0 / SETTINGS.tf_cache_lookup_frequency
                 )

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -174,7 +174,7 @@ class TfCache(object):
         self.buffer = tf2_py.BufferCore(TfDuration.from_sec(max_time_sec))
         # Cache presence is tracked by storing the start time of each TF topic/bag combo.
         self.cache: dict[CacheKey, TimeSpec] = {}
-        self.debug = debug
+        self.debug = debug and logger.isEnabledFor(logging.DEBUG)
 
     def clear(self) -> None:
         logger.debug("Clearing TF cache.")
@@ -296,7 +296,7 @@ class TfCache(object):
                     else:
                         self.buffer.set_transform(native_msg, __name__)
 
-            if self.debug and logger.isEnabledFor(logging.DEBUG):
+            if self.debug:
                 logger.debug("TF buffer:\n" + self.buffer.all_frames_as_yaml())
 
     def lookup_trajectory(

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -47,6 +47,8 @@ from evo.tools.settings import SETTINGS
 logger = logging.getLogger(__name__)
 
 SUPPORTED_TF_MSG = "tf2_msgs/msg/TFMessage"
+DEFAULT_MAX_TIME = SETTINGS.tf_cache_max_time
+DEFAULT_DEBUG = SETTINGS.tf_cache_debug and logger.isEnabledFor(logging.DEBUG)
 
 
 class TfCacheException(EvoException):
@@ -130,7 +132,9 @@ def to_sec(
 
 @dataclasses.dataclass
 class TimeSpec:
-    """Internal timespec for time tracking."""
+    """
+    Internal timespec for time tracking.
+    """
 
     sec: int
     nanosec: int
@@ -138,7 +142,9 @@ class TimeSpec:
 
 @dataclasses.dataclass
 class CacheKey:
-    """Key for presence tracking in TfCache"""
+    """
+    Key for presence tracking in TfCache.
+    """
 
     reader: Rosbag1Reader | Rosbag2Reader
     topic: str
@@ -151,17 +157,24 @@ class CacheKey:
 class TfCache(object):
     """
     For caching TF messages and looking up trajectories of specific transforms.
+
+    Allows to use multiple bag files and TF topics.
     """
 
-    def __init__(self) -> None:
-        self.buffer = tf2_py.BufferCore(
-            TfDuration.from_sec(SETTINGS.tf_cache_max_time)
-        )
+    def __init__(
+        self,
+        *,
+        max_time_sec: float = DEFAULT_MAX_TIME,
+        debug: bool = DEFAULT_DEBUG,
+    ) -> None:
+        """
+        :param max_time_sec: Maximum TF buffer size in seconds.
+        :param debug: Whether to emit debug logs with TF buffer details.
+        """
+        self.buffer = tf2_py.BufferCore(TfDuration.from_sec(max_time_sec))
         # Cache presence is tracked by storing the start time of each TF topic/bag combo.
         self.cache: dict[CacheKey, TimeSpec] = {}
-        self.debug = SETTINGS.tf_cache_debug and logger.isEnabledFor(
-            logging.DEBUG
-        )
+        self.debug = debug
 
     def clear(self) -> None:
         logger.debug("Clearing TF cache.")

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -151,12 +151,6 @@ class CacheKey:
         return hash(f"{self.reader.path}+{self.topic}")
 
 
-@dataclasses.dataclass
-class CacheEntry:
-    # Earliest timestamp of a TF message on this topic.
-    start_time: TimeSpec
-
-
 class TfCache(object):
     """
     For caching TF messages and looking up trajectories of specific transforms.
@@ -166,7 +160,8 @@ class TfCache(object):
         self.buffer = tf2_py.BufferCore(
             TfDuration.from_sec(SETTINGS.tf_cache_max_time)
         )
-        self.cache: dict[CacheKey, CacheEntry] = {}
+        # Cache presence is tracked by storing the start time of each TF topic/bag combo.
+        self.cache: dict[CacheKey, TimeSpec] = {}
 
     def clear(self) -> None:
         logger.debug("Clearing TF cache.")
@@ -255,7 +250,7 @@ class TfCache(object):
                         start_time = TimeSpec(
                             tf.header.stamp.sec, tf.header.stamp.nanosec
                         )
-                        self.cache[cache_key] = CacheEntry(start_time)
+                        self.cache[cache_key] = start_time
 
                     # Convert from rosbags.typesys.types to native ROS.
                     # Related: https://gitlab.com/ternaris/rosbags/-/issues/13
@@ -354,9 +349,7 @@ class TfCache(object):
             except (tf2_py.LookupException, tf2_py.TransformException) as e:
                 raise TfCacheException("Could not load trajectory: " + str(e))
 
-            _start_time: TimeSpec = self.cache[
-                CacheKey(reader, topic)
-            ].start_time
+            _start_time: TimeSpec = self.cache[CacheKey(reader, topic)]
 
             if hasattr(latest_time, "nsecs"):
                 from rospy import (

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -130,16 +130,21 @@ def to_sec(
 
 @dataclasses.dataclass
 class TimeSpec:
+    """Internal timespec for time tracking."""
+
     sec: int
     nanosec: int
 
 
 @dataclasses.dataclass
 class CacheKey:
+    """Key for presence tracking in TfCache"""
+
     reader: Rosbag1Reader | Rosbag2Reader
     topic: str
 
     def __hash__(self):
+        """Hash for a bag & TF topic pair."""
         return hash(f"{self.reader.path}+{self.topic}")
 
 
@@ -154,7 +159,9 @@ class TfCache(object):
         )
         # Cache presence is tracked by storing the start time of each TF topic/bag combo.
         self.cache: dict[CacheKey, TimeSpec] = {}
-        self.debug = SETTINGS.tf_cache_debug and logger.isEnabledFor(logging.DEBUG)
+        self.debug = SETTINGS.tf_cache_debug and logger.isEnabledFor(
+            logging.DEBUG
+        )
 
     def clear(self) -> None:
         logger.debug("Clearing TF cache.")
@@ -275,9 +282,8 @@ class TfCache(object):
                         self.buffer.set_transform_static(native_msg, __name__)
                     else:
                         self.buffer.set_transform(native_msg, __name__)
-
-        if self.debug:
-            logger.debug("TF buffer:\n" + self.buffer.all_frames_as_yaml())
+            if self.debug:
+                logger.debug("TF buffer:\n" + self.buffer.all_frames_as_yaml())
 
     def lookup_trajectory(
         self,

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -205,7 +205,7 @@ class TfCache(object):
 
         # Add TF data to buffer if this bag/topic pair is not already cached.
         for tf_topic in tf_topics:
-            cache_key = CacheKey(reader, topic)
+            cache_key = CacheKey(reader, tf_topic)
             if cache_key in self.cache:
                 logger.debug(
                     f"Using cache for topic {tf_topic} from {reader.path}"
@@ -275,6 +275,9 @@ class TfCache(object):
                     else:
                         self.buffer.set_transform(native_msg, __name__)
 
+        if SETTINGS.tf_cache_debug and logger.isEnabledFor(logging.DEBUG):
+            logger.debug("TF buffer:\n" + self.buffer.all_frames_as_yaml())
+
     def lookup_trajectory(
         self,
         parent_frame: str,
@@ -339,7 +342,13 @@ class TfCache(object):
             try:
                 latest_time = self.buffer.get_latest_common_time(parent, child)
             except (tf2_py.LookupException, tf2_py.TransformException) as e:
-                raise TfCacheException("Could not load trajectory: " + str(e))
+                error = f"Could not load trajectory: {e}"
+                if not SETTINGS.tf_cache_debug:
+                    error += (
+                        "\nEnable 'evo_config set tf_cache_debug true' and "
+                        "verbose/debug logging to see TF buffer contents."
+                    )
+                raise TfCacheException(error)
 
             _start_time: TimeSpec = self.cache[CacheKey(reader, topic)]
 

--- a/evo/tools/tf_cache.py
+++ b/evo/tools/tf_cache.py
@@ -154,6 +154,7 @@ class TfCache(object):
         )
         # Cache presence is tracked by storing the start time of each TF topic/bag combo.
         self.cache: dict[CacheKey, TimeSpec] = {}
+        self.debug = SETTINGS.tf_cache_debug and logger.isEnabledFor(logging.DEBUG)
 
     def clear(self) -> None:
         logger.debug("Clearing TF cache.")
@@ -275,7 +276,7 @@ class TfCache(object):
                     else:
                         self.buffer.set_transform(native_msg, __name__)
 
-        if SETTINGS.tf_cache_debug and logger.isEnabledFor(logging.DEBUG):
+        if self.debug:
             logger.debug("TF buffer:\n" + self.buffer.all_frames_as_yaml())
 
     def lookup_trajectory(
@@ -341,14 +342,17 @@ class TfCache(object):
 
             try:
                 latest_time = self.buffer.get_latest_common_time(parent, child)
-            except (tf2_py.LookupException, tf2_py.TransformException) as e:
-                error = f"Could not load trajectory: {e}"
-                if not SETTINGS.tf_cache_debug:
+            except (
+                tf2_py.LookupException,
+                tf2_py.TransformException,
+            ) as tf_error:
+                error = f"Could not load trajectory: {tf_error}"
+                if not self.debug:
                     error += (
                         "\nEnable 'evo_config set tf_cache_debug true' and "
                         "verbose/debug logging to see TF buffer contents."
                     )
-                raise TfCacheException(error)
+                raise TfCacheException(error) from tf_error
 
             _start_time: TimeSpec = self.cache[CacheKey(reader, topic)]
 

--- a/test/traj_smoke_test.py
+++ b/test/traj_smoke_test.py
@@ -29,6 +29,7 @@ if os.getenv("ROS_DISTRO") is not None:
         {
             "evo_traj bag data/tf_example.bag /tf:odom.base_link --ref /tf:odom.base_footprint": "cfg/traj/bag",
             "evo_traj bag2 data/tf_example /tf:odom.base_link --ref /tf:odom.base_footprint": "cfg/traj/bag",
+            "evo_traj bag2 data/nav2_turtlebot.mcap /tf:odom.base_link --ref /tf:map.base_link": "cfg/traj/bag",
         }
     )
 

--- a/test/traj_smoke_test.py
+++ b/test/traj_smoke_test.py
@@ -29,7 +29,8 @@ if os.getenv("ROS_DISTRO") is not None:
         {
             "evo_traj bag data/tf_example.bag /tf:odom.base_link --ref /tf:odom.base_footprint": "cfg/traj/bag",
             "evo_traj bag2 data/tf_example /tf:odom.base_link --ref /tf:odom.base_footprint": "cfg/traj/bag",
-            "evo_traj bag2 data/nav2_turtlebot.mcap /tf:odom.base_link --ref /tf:map.base_link": "cfg/traj/bag",
+            "evo_traj bag2 data/nav2_turtlebot.mcap /tf:odom.base_link "
+            "--ref /tf:map.base_link": "cfg/traj/bag",
         }
     )
 


### PR DESCRIPTION
More robust than `reader.start_time`, e.g. when sim time was recorded.

Cache logic is fixed/improved for correct start time tracking per file & topic.

TF buffers can now also be debugged via `evo_config set tf_cache_debug true` + `--verbose` / DEBUG logging.

Closes: #771